### PR TITLE
Add Auth Mount Path Config (Env / Annotation)

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	DefaultVaultImage = "vault:1.3.1"
+	DefaultVaultAuthPath = "auth/kubernetes"
 )
 
 // Agent is the top level structure holding all the
@@ -101,6 +102,9 @@ type Vault struct {
 	// Address is the Vault service address.
 	Address string
 
+	// AuthPath is the Mount Path of Vault Kubernetes Auth Method.
+	AuthPath string
+
 	// CACert is the name of the Certificate Authority certificate
 	// to use when validating Vault's server certificates.
 	CACert string
@@ -161,6 +165,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		Status:             pod.Annotations[AnnotationAgentStatus],
 		Vault: Vault{
 			Address:          pod.Annotations[AnnotationVaultService],
+			AuthPath:         pod.Annotations[AnnotationVaultAuthPath],
 			CACert:           pod.Annotations[AnnotationVaultCACert],
 			CAKey:            pod.Annotations[AnnotationVaultCAKey],
 			ClientCert:       pod.Annotations[AnnotationVaultClientCert],
@@ -324,6 +329,10 @@ func (a *Agent) Validate() error {
 	if a.ConfigMapName == "" {
 		if a.Vault.Role == "" {
 			return errors.New("no Vault role found")
+		}
+
+		if a.Vault.AuthPath == "" {
+			return errors.New("no Vault Auth Path found")
 		}
 
 		if a.Vault.Address == "" {

--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -77,6 +77,7 @@ func TestValidate(t *testing.T) {
 				Vault: Vault{
 					Role:    "test",
 					Address: "https://foobar.com:8200",
+					AuthPath: "test",
 				},
 			}, true,
 		},
@@ -137,6 +138,19 @@ func TestValidate(t *testing.T) {
 				Vault: Vault{
 					Role:    "test",
 					Address: "",
+				},
+			}, false,
+		},
+		{
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				ImageName:          "test",
+				Vault: Vault{
+					Role:    "test",
+					Address: "https://foobar.com:8200",
+					AuthPath: "",
 				},
 			}, false,
 		},

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -108,18 +108,26 @@ const (
 	// AnnotationAgentRole specifies the role to be used for the Kubernetes auto-auth
 	// method.
 	AnnotationVaultRole = "vault.hashicorp.com/role"
+
+	// AnnotationVaultAuthPath specifies the mount path to be used for the Kubernetes auto-auth
+	// method.
+	AnnotationVaultAuthPath = "vault.hashicorp.com/auth-path"
 )
 
 // Init configures the expected annotations required to create a new instance
 // of Agent.  This should be run before running new to ensure all annotations are
 // present.
-func Init(pod *corev1.Pod, image, address, namespace string) error {
+func Init(pod *corev1.Pod, image, address, authPath, namespace string) error {
 	if pod == nil {
 		return errors.New("pod is empty")
 	}
 
 	if address == "" {
 		return errors.New("address for Vault required")
+	}
+
+	if authPath == "" {
+		return errors.New("Vault Auth Path required")
 	}
 
 	if namespace == "" {
@@ -132,6 +140,10 @@ func Init(pod *corev1.Pod, image, address, namespace string) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultService]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationVaultService] = address
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultAuthPath]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationVaultAuthPath] = authPath
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentImage]; !ok {

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -13,7 +13,7 @@ func TestInitCanSet(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, "foobar-image", "http://foobar:8200", "test")
+	err := Init(pod, "foobar-image", "http://foobar:8200", "test", "test")
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -44,7 +44,7 @@ func TestInitDefaults(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, "", "http://foobar:8200", "test")
+	err := Init(pod, "", "http://foobar:8200", "test", "test")
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -73,7 +73,7 @@ func TestInitError(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, "image", "", "namespace")
+	err := Init(pod, "image", "", "authPath", "namespace")
 	if err == nil {
 		t.Error("expected error no address, got none")
 	}
@@ -83,7 +83,17 @@ func TestInitError(t *testing.T) {
 		t.Errorf("expected '%s' error, got %s", errMsg, err)
 	}
 
-	err = Init(pod, "image", "address", "")
+	err = Init(pod, "image", "address", "", "namespace")
+	if err == nil {
+		t.Error("expected error no authPath, got none")
+	}
+
+	errMsg = "Vault Auth Path required"
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Errorf("expected '%s' error, got %s", errMsg, err)
+	}
+
+	err = Init(pod, "image", "address", "authPath", "")
 	if err == nil {
 		t.Error("expected error for no namespace, got none")
 	}
@@ -268,7 +278,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 func TestInitEmptyPod(t *testing.T) {
 	var pod *corev1.Pod
 
-	err := Init(pod, "foobar-image", "http://foobar:8200", "test")
+	err := Init(pod, "foobar-image", "http://foobar:8200", "test", "test")
 	if err == nil {
 		t.Errorf("got no error, shouldn have")
 	}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -105,6 +105,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		AutoAuth: &AutoAuth{
 			Method: &Method{
 				Type: "kubernetes",
+				MountPath: a.Vault.AuthPath,
 				Config: map[string]interface{}{
 					"role": a.Vault.Role,
 				},

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -78,6 +78,10 @@ func TestNewConfig(t *testing.T) {
 		t.Errorf("auto_auth role: expected role to be %s, got %s", annotations[AnnotationVaultRole], config.AutoAuth.Method.Config["role"])
 	}
 
+	if config.AutoAuth.Method.MountPath != annotations[AnnotationVaultAuthPath] {
+		t.Errorf("auto_auth mount path: expected path to be %s, got %s", annotations[AnnotationVaultAuthPath], config.AutoAuth.Method.MountPath)
+	}
+
 	if len(config.Templates) != 2 {
 		t.Errorf("expected 2 template, got %d", len(config.Templates))
 	}

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -15,7 +15,7 @@ func TestContainerSidecar(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, "foobar-image", "http://foobar:1234", "test")
+	err := Init(pod, "foobar-image", "http://foobar:1234", "test", "test")
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -89,7 +89,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, "foobar-image", "http://foobar:1234", "test")
+	err := Init(pod, "foobar-image", "http://foobar:1234", "test", "test")
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -37,6 +37,7 @@ type Handler struct {
 	// If this is false, injection is default.
 	RequireAnnotation bool
 	VaultAddress      string
+	VaultAuthPath	  string
 	ImageVault        string
 	Clientset         *kubernetes.Clientset
 	Log               hclog.Logger
@@ -134,7 +135,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 
 	h.Log.Debug("setting default annotations..")
 	var patches []*jsonpatch.JsonPatchOperation
-	err = agent.Init(&pod, h.ImageVault, h.VaultAddress, req.Namespace)
+	err = agent.Init(&pod, h.ImageVault, h.VaultAddress, h.VaultAuthPath, req.Namespace)
 	if err != nil {
 		err := fmt.Errorf("error adding default annotations: %s", err)
 		return admissionError(err)

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -83,7 +83,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"injection disabled",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -102,7 +102,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"basic pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -142,7 +142,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -186,7 +186,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -235,7 +235,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -280,7 +280,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap no init pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -322,7 +322,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap init only pod injection",
-			Handler{VaultAddress: "https://vault:8200", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -27,14 +27,15 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flagListen       string // Address of Vault Server
-	flagLogLevel     string // Log verbosity
-	flagCertFile     string // TLS Certificate to serve
-	flagKeyFile      string // TLS private key to serve
-	flagAutoName     string // MutatingWebhookConfiguration for updating
-	flagAutoHosts    string // SANs for the auto-generated TLS cert.
-	flagVaultService string // Name of the Vault service
-	flagVaultImage   string // Name of the Vault Image to use
+	flagListen       	string // Address of Vault Server
+	flagLogLevel     	string // Log verbosity
+	flagCertFile     	string // TLS Certificate to serve
+	flagKeyFile      	string // TLS private key to serve
+	flagAutoName     	string // MutatingWebhookConfiguration for updating
+	flagAutoHosts    	string // SANs for the auto-generated TLS cert.
+	flagVaultService 	string // Name of the Vault service
+	flagVaultImage   	string // Name of the Vault Image to use
+	flagVaultAuthPath	string // Mount Path of the Vault Kubernetes Auth Method
 
 	flagSet *flag.FlagSet
 
@@ -107,6 +108,7 @@ func (c *Command) Run(args []string) int {
 	// Build the HTTP handler and server
 	injector := agentInject.Handler{
 		VaultAddress:      c.flagVaultService,
+		VaultAuthPath:     c.flagVaultAuthPath,
 		ImageVault:        c.flagVaultImage,
 		Clientset:         clientset,
 		RequireAnnotation: true,

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -42,6 +42,10 @@ type Specification struct {
 
 	// VaultImage is the AGENT_INJECT_VAULT_IMAGE environment variable.
 	VaultImage string `split_words:"true"`
+
+	// VaultAuthPath is the AGENT_INJECT_VAULT_AUTH_PATH environment variable.
+	VaultAuthPath string `split_words:"true"`
+
 }
 
 func (c *Command) init() {
@@ -61,6 +65,8 @@ func (c *Command) init() {
 		fmt.Sprintf("Docker image for Vault. Defaults to %q.", agent.DefaultVaultImage))
 	c.flagSet.StringVar(&c.flagVaultService, "vault-address", "",
 		"Address of the Vault server.")
+	c.flagSet.StringVar(&c.flagVaultAuthPath, "vault-auth-path", agent.DefaultVaultAuthPath,
+		fmt.Sprintf("Mount Path of the Vault Kubernetes Auth Method. Defaults to %q.", agent.DefaultVaultAuthPath))
 
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -125,6 +131,10 @@ func (c *Command) parseEnvs() error {
 
 	if envs.VaultAddr != "" {
 		c.flagVaultService = envs.VaultAddr
+	}
+
+	if envs.VaultAuthPath != "" {
+		c.flagVaultAuthPath = envs.VaultAuthPath
 	}
 
 	return nil

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -112,6 +112,7 @@ func TestCommandEnvs(t *testing.T) {
 	}{
 		{env: "AGENT_INJECT_LISTEN", value: ":8080", cmdPtr: &cmd.flagListen},
 		{env: "AGENT_INJECT_VAULT_ADDR", value: "http://vault:8200", cmdPtr: &cmd.flagVaultService},
+		{env: "AGENT_INJECT_VAULT_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagVaultAuthPath},
 		{env: "AGENT_INJECT_VAULT_IMAGE", value: "hashicorp/vault:1.3.1", cmdPtr: &cmd.flagVaultImage},
 		{env: "AGENT_INJECT_TLS_KEY_FILE", value: "server.key", cmdPtr: &cmd.flagKeyFile},
 		{env: "AGENT_INJECT_TLS_CERT_FILE", value: "server.crt", cmdPtr: &cmd.flagCertFile},


### PR DESCRIPTION
## How to use
### Method 1. Set sidecar-injector container environment variable
```yaml
- name: AGENT_INJECT_VAULT_AUTH_PATH
  value: "auth/kubernetes"
```

### Method 2. Add target pod annotation
```yaml
vault.hashicorp.com/auth-path: "auth/kubernetes"
```