### PR TITLE
add "command" annotation for executing after secret template is rendered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build
 build:
 	GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -a -o $(BUILD_DIR)/$(BIN_NAME) .
 
-image: build 
+image: build
 	docker build --build-arg NAME=$(IMAGE_NAME) --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) -f $(DOCKER_DIR)/Dockerfile.dev .
 
 docker-login:
@@ -27,7 +27,7 @@ deploy: image docker-login
 	docker push $(IMAGE_TAG_LATEST)
 
 clean:
-	-rm -rf $(BUILD_DIR) 
+	-rm -rf $(BUILD_DIR)
 
 test: unit-test
 

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -14,7 +14,7 @@ import (
 // TODO swap out 'github.com/mattbaird/jsonpatch' for 'github.com/evanphx/json-patch'
 
 const (
-	DefaultVaultImage = "vault:1.3.1"
+	DefaultVaultImage    = "vault:1.3.1"
 	DefaultVaultAuthPath = "auth/kubernetes"
 )
 
@@ -96,6 +96,9 @@ type Secret struct {
 
 	// Template is the optional custom template to use when rendering the secret.
 	Template string
+
+	// Command is the optional command to run after rendering the secret.
+	Command string
 }
 
 type Vault struct {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -39,6 +39,13 @@ const (
 	// from auth/token/lookup-self
 	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token"
 
+	// AnnotationAgentInjectCommand is the key annotation that configures Vault Agent
+	// to run a command after the secret is rendered. The name of the template is any
+	// unique string after "vault.hashicorp.com/agent-inject-command-". This should map
+	// to the same unique value provided in ""vault.hashicorp.com/agent-inject-secret-".
+	// If not provided (the default), no command is executed.
+	AnnotationAgentInjectCommand = "vault.hashicorp.com/agent-inject-command"
+
 	// AnnotationAgentImage is the name of the Vault docker image to use.
 	AnnotationAgentImage = "vault.hashicorp.com/agent-image"
 
@@ -210,7 +217,14 @@ func secrets(annotations map[string]string) []*Secret {
 				template = val
 			}
 
-			secrets = append(secrets, &Secret{Name: name, Path: path, Template: template})
+			var command string
+			commandName := fmt.Sprintf("%s-%s", AnnotationAgentInjectCommand, raw)
+
+			if val, ok := annotations[commandName]; ok {
+				command = val
+			}
+
+			secrets = append(secrets, &Secret{Name: name, Path: path, Template: template, Command: command})
 		}
 	}
 	return secrets

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -70,6 +70,7 @@ type Template struct {
 	Contents       string `json:"contents"`
 	LeftDelim      string `json:"left_delimiter,omitempty"`
 	RightDelim     string `json:"right_delimiter,omitempty"`
+	Command        string `json:"command,omitempty"`
 }
 
 func (a *Agent) newTemplateConfigs() []*Template {
@@ -85,6 +86,7 @@ func (a *Agent) newTemplateConfigs() []*Template {
 			Destination: fmt.Sprintf("/vault/secrets/%s", secret.Name),
 			LeftDelim:   "{{",
 			RightDelim:  "}}",
+			Command:     secret.Command,
 		}
 		templates = append(templates, tmpl)
 	}

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -25,6 +25,7 @@ func TestNewConfig(t *testing.T) {
 		"vault.hashicorp.com/agent-inject-secret-foo":   "db/creds/foo",
 		"vault.hashicorp.com/agent-inject-template-foo": "template foo",
 		"vault.hashicorp.com/agent-inject-secret-bar":   "db/creds/bar",
+		"vault.hashicorp.com/agent-inject-command-bar":  "pkill -HUP app",
 	}
 
 	pod := testPod(annotations)
@@ -101,6 +102,10 @@ func TestNewConfig(t *testing.T) {
 
 			if !strings.Contains(template.Contents, "with secret \"db/creds/bar\"") {
 				t.Errorf("expected template contents to contain %s, got %s", "with secret \"db/creds/bar\"", template.Contents)
+			}
+
+			if !strings.Contains(template.Command, "pkill -HUP app") {
+				t.Errorf("expected command contents to contain %s, got %s", "pkill -HUP app", template.Command)
 			}
 		} else {
 			t.Error("shouldn't have got here")


### PR DESCRIPTION
Addresses #56 

This PR adds a new annotation:
* `vault.hashicorp.com/agent-inject-command-` 

This annotation similar to the one used for customizing the secret template. The specified command will be run by vault-agent after the secret is rendered.

Unaddressed by this PR is that in many cases the vault agent will be running as a different user than the main app container. Thus, the example use case from #56 is not yet fully possible since the call to `pkill` will be run as a different user/uid than the nginx container.

It may be desirable to allow an annotation that will set the UID of the vault agent container to address this.

**EDIT**: support for specifying the userid/groupid of the vault agent sidecar is addressed in #60 