### PR TITLE
Write Vault Token to the usual location

### DIFF
--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -9,7 +9,7 @@ import (
 const (
 	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
 	PidFile         = "/home/vault/.pid"
-	TokenFile       = "/home/vault/.token"
+	TokenFile       = "/home/vault/.vault-token"
 )
 
 // Config is the top level struct that composes a Vault Agent
@@ -104,7 +104,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		},
 		AutoAuth: &AutoAuth{
 			Method: &Method{
-				Type: "kubernetes",
+				Type:      "kubernetes",
 				MountPath: a.Vault.AuthPath,
 				Config: map[string]interface{}{
 					"role": a.Vault.Role,

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -37,7 +37,7 @@ type Handler struct {
 	// If this is false, injection is default.
 	RequireAnnotation bool
 	VaultAddress      string
-	VaultAuthPath	  string
+	VaultAuthPath     string
 	ImageVault        string
 	Clientset         *kubernetes.Clientset
 	Log               hclog.Logger

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -89,7 +89,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"injection disabled",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -108,7 +108,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"basic pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -148,7 +148,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -192,7 +192,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -241,7 +241,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -286,7 +286,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap no init pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -328,7 +328,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap init only pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath:"kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{


### PR DESCRIPTION
As documented by the default token helper: https://www.vaultproject.io/docs/commands/token-helper/

