### PR TITLE
Support for a "token-only" injection annotation

### DIFF
--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -35,6 +35,10 @@ const (
 	// If not provided, a default generic template is used.
 	AnnotationAgentInjectTemplate = "vault.hashicorp.com/agent-inject-template"
 
+	// AnnotationAgentInjectToken is the annotation key for injecting the token
+	// from auth/token/lookup-self
+	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token-only"
+
 	// AnnotationAgentImage is the name of the Vault docker image to use.
 	AnnotationAgentImage = "vault.hashicorp.com/agent-image"
 
@@ -184,6 +188,11 @@ func Init(pod *corev1.Pod, image, address, authPath, namespace string) error {
 // name: foobar, value: db/creds/foobar
 func secrets(annotations map[string]string) []*Secret {
 	var secrets []*Secret
+	// First check for the token-only injection annotation
+	if _, found := annotations[AnnotationAgentInjectToken]; found {
+		annotations[fmt.Sprintf("%s-%s", AnnotationAgentInjectSecret, "token")] = TokenSecret
+		annotations[fmt.Sprintf("%s-%s", AnnotationAgentInjectTemplate, "token")] = TokenTemplate
+	}
 	for name, path := range annotations {
 		secretName := fmt.Sprintf("%s-", AnnotationAgentInjectSecret)
 		if strings.Contains(name, secretName) {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -37,7 +37,7 @@ const (
 
 	// AnnotationAgentInjectToken is the annotation key for injecting the token
 	// from auth/token/lookup-self
-	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token-only"
+	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token"
 
 	// AnnotationAgentImage is the name of the Vault docker image to use.
 	AnnotationAgentImage = "vault.hashicorp.com/agent-image"

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -226,22 +226,22 @@ func TestTemplateShortcuts(t *testing.T) {
 		expectedSecrets map[string]Secret
 	}{
 		{
-			"valid inject-token-only",
+			"valid inject-token",
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-token-only": "true",
+				AnnotationAgentInjectToken: "true",
 			},
 			map[string]Secret{
 				"token": Secret{
 					Name:     "token",
-					Path:     "auth/token/lookup-self",
-					Template: `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}{{ end }}`,
+					Path:     TokenSecret,
+					Template: TokenTemplate,
 				},
 			},
 		},
 		{
-			"invalid inject-token-only",
+			"invalid inject-token",
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-token": "true",
+				"vault.hashicorp.com/agent-inject-token-invalid": "true",
 			},
 			map[string]Secret{},
 		},

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -215,6 +216,66 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 		if agent.Secrets[0].Name != tt.expectedKey {
 			t.Errorf("expected template %s, got %s", tt.expectedTemplate, agent.Secrets[0].Template)
 		}
+	}
+}
+
+func TestTemplateShortcuts(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		expectedSecrets map[string]Secret
+	}{
+		{
+			"valid inject-token-only",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-token-only": "true",
+			},
+			map[string]Secret{
+				"token": Secret{
+					Name:     "token",
+					Path:     "auth/token/lookup-self",
+					Template: `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}{{ end }}`,
+				},
+			},
+		},
+		{
+			"invalid inject-token-only",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-token": "true",
+			},
+			map[string]Secret{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := testPod(tt.annotations)
+			var patches []*jsonpatch.JsonPatchOperation
+
+			agent, err := New(pod, patches)
+			if err != nil {
+				t.Errorf("got error, shouldn't have: %s", err)
+			}
+
+			if len(agent.Secrets) != len(tt.expectedSecrets) {
+				t.Errorf("agent Secrets length was %d, expected %d", len(agent.Secrets), len(tt.expectedSecrets))
+			}
+
+			for _, s := range agent.Secrets {
+				if s == nil {
+					t.Error("Got a nil agent Secret")
+					t.FailNow()
+				}
+				expectedSecret, found := tt.expectedSecrets[s.Name]
+				if !found {
+					t.Errorf("Unexpected agent secret name %q", s.Name)
+					t.FailNow()
+				}
+				if !reflect.DeepEqual(expectedSecret, *s) {
+					t.Errorf("expected secret %+v, got agent secret %+v", expectedSecret, *s)
+				}
+			}
+		})
 	}
 }
 

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -8,6 +8,8 @@ import (
 
 const (
 	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
+	TokenTemplate   = `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}{{ end }}`
+	TokenSecret     = "auth/token/lookup-self"
 	PidFile         = "/home/vault/.pid"
 	TokenFile       = "/home/vault/.token"
 )
@@ -104,7 +106,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		},
 		AutoAuth: &AutoAuth{
 			Method: &Method{
-				Type: "kubernetes",
+				Type:      "kubernetes",
 				MountPath: a.Vault.AuthPath,
 				Config: map[string]interface{}{
 					"role": a.Vault.Role,

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
-	TokenTemplate   = `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}\n{{ end }}`
+	TokenTemplate   = "{{ with secret \"auth/token/lookup-self\" }}{{ .Data.id }}\n{{ end }}"
 	TokenSecret     = "auth/token/lookup-self"
 	PidFile         = "/home/vault/.pid"
 	TokenFile       = "/home/vault/.token"

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
-	TokenTemplate   = `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}{{ end }}`
+	TokenTemplate   = `{{ with secret "auth/token/lookup-self" }}{{ .Data.id }}\n{{ end }}`
 	TokenSecret     = "auth/token/lookup-self"
 	PidFile         = "/home/vault/.pid"
 	TokenFile       = "/home/vault/.token"

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/api v0.0.0-20180829000535-087779f1d2c9/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=


### PR DESCRIPTION
The annotation `"vault.hashicorp.com/agent-inject-token": "true"`
results in a `token` file containing the `lookup-self` token.

Resolves #16 