### PR TITLE
Add namespace and log level annotations

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -132,6 +132,12 @@ type Vault struct {
 	// make a request to the Vault server.
 	ClientTimeout string
 
+	// LogLevel sets the Vault Agent log level.  Defaults to info.
+	LogLevel string
+
+	// Namespace is the Vault namespace to prepend to secret paths.
+	Namespace string
+
 	// Role is the name of the Vault role to use for authentication.
 	Role string
 
@@ -175,6 +181,8 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 			ClientKey:        pod.Annotations[AnnotationVaultClientKey],
 			ClientMaxRetries: pod.Annotations[AnnotationVaultClientMaxRetries],
 			ClientTimeout:    pod.Annotations[AnnotationVaultClientTimeout],
+			LogLevel:         pod.Annotations[AnnotationVaultLogLevel],
+			Namespace:        pod.Annotations[AnnotationVaultNamespace],
 			Role:             pod.Annotations[AnnotationVaultRole],
 			TLSSecret:        pod.Annotations[AnnotationVaultTLSSecret],
 			TLSServerName:    pod.Annotations[AnnotationVaultTLSServerName],

--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -75,8 +75,8 @@ func TestValidate(t *testing.T) {
 				ServiceAccountName: "foobar",
 				ImageName:          "test",
 				Vault: Vault{
-					Role:    "test",
-					Address: "https://foobar.com:8200",
+					Role:     "test",
+					Address:  "https://foobar.com:8200",
 					AuthPath: "test",
 				},
 			}, true,
@@ -148,8 +148,8 @@ func TestValidate(t *testing.T) {
 				ServiceAccountName: "foobar",
 				ImageName:          "test",
 				Vault: Vault{
-					Role:    "test",
-					Address: "https://foobar.com:8200",
+					Role:     "test",
+					Address:  "https://foobar.com:8200",
 					AuthPath: "",
 				},
 			}, false,

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -79,6 +79,9 @@ const (
 	// AnnotationAgentRequestsMem sets the requested memory amount on the Vault Agent containers.
 	AnnotationAgentRequestsMem = "vault.hashicorp.com/agent-requests-mem"
 
+	// AnnotationVaultNamespace is the Vault namespace where secrets can be found.
+	AnnotationVaultNamespace = "vault.hashicorp.com/namespace"
+
 	// AnnotationVaultService is the name of the Vault server.  This can be overridden by the
 	// user but will be set by a flag on the deployment.
 	AnnotationVaultService = "vault.hashicorp.com/service"
@@ -115,6 +118,9 @@ const (
 
 	// AnnotationVaultClientTimeout sets the request timeout when communicating with Vault.
 	AnnotationVaultClientTimeout = "vault.hashicorp.com/client-timeout"
+
+	// AnnotationVaultLogLevel sets the Vault Agent log level.
+	AnnotationVaultLogLevel = "vault.hashicorp.com/log-level"
 
 	// AnnotationVaultRole specifies the role to be used for the Kubernetes auto-auth
 	// method.
@@ -182,6 +188,10 @@ func Init(pod *corev1.Pod, image, address, authPath, namespace string) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentRequestsMem]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentRequestsMem] = DefaultResourceRequestMem
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultLogLevel]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationVaultLogLevel] = DefaultAgentLogLevel
 	}
 
 	return nil

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -399,3 +399,33 @@ func TestInitEmptyPod(t *testing.T) {
 		t.Errorf("got no error, shouldn have")
 	}
 }
+
+func TestVaultNamespaceAnnotation(t *testing.T) {
+	tests := []struct {
+		key           string
+		value         string
+		expectedValue string
+	}{
+		{"", "", ""},
+		{"vault.hashicorp.com/namespace", "", ""},
+		{"vault.hashicorp.com/namespace", "foobar", "foobar"},
+		{"vault.hashicorp.com/namespace", "fooBar", "fooBar"},
+	}
+
+	for _, tt := range tests {
+		annotation := map[string]string{
+			tt.key: tt.value,
+		}
+		pod := testPod(annotation)
+		var patches []*jsonpatch.JsonPatchOperation
+
+		agent, err := New(pod, patches)
+		if err != nil {
+			t.Errorf("got error, shouldn't have: %s", err)
+		}
+
+		if agent.Vault.Namespace != tt.expectedValue {
+			t.Errorf("expected %s, got %s", tt.expectedValue, agent.Vault.Namespace)
+		}
+	}
+}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -109,6 +109,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		AutoAuth: &AutoAuth{
 			Method: &Method{
 				Type:      "kubernetes",
+				Namespace: a.Vault.Namespace,
 				MountPath: a.Vault.AuthPath,
 				Config: map[string]interface{}{
 					"role": a.Vault.Role,

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -10,6 +10,11 @@ import (
 func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 	var envs []corev1.EnvVar
 
+	envs = append(envs, corev1.EnvVar{
+		Name:  "VAULT_TOKEN",
+		Value: "/home/vault/.vault-token",
+	})
+
 	if a.Vault.ClientTimeout != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLIENT_TIMEOUT",
@@ -21,6 +26,13 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_MAX_RETRIES",
 			Value: a.Vault.ClientMaxRetries,
+		})
+	}
+
+	if a.Vault.LogLevel != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "VAULT_LOG_LEVEL",
+			Value: a.Vault.LogLevel,
 		})
 	}
 

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -10,11 +10,6 @@ import (
 func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 	var envs []corev1.EnvVar
 
-	envs = append(envs, corev1.EnvVar{
-		Name:  "VAULT_TOKEN",
-		Value: "/home/vault/.vault-token",
-	})
-
 	if a.Vault.ClientTimeout != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLIENT_TIMEOUT",

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -12,12 +12,12 @@ func TestContainerEnvs(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{}, []string{"VAULT_CONFIG", "VAULT_TOKEN"}},
-		{Agent{ConfigMapName: "foobar"}, []string{"VAULT_TOKEN"}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_TOKEN"}},
-		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT", "VAULT_TOKEN"}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_TOKEN"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "VAULT_TOKEN"}},
+		{Agent{}, []string{"VAULT_CONFIG"}},
+		{Agent{ConfigMapName: "foobar"}, []string{}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
+		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL"}},
 	}
 
 	for _, tt := range tests {

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -12,12 +12,12 @@ func TestContainerEnvs(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{}, []string{"VAULT_CONFIG"}},
-		{Agent{ConfigMapName: "foobar"}, []string{}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
-		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
+		{Agent{}, []string{"VAULT_CONFIG", "VAULT_TOKEN"}},
+		{Agent{ConfigMapName: "foobar"}, []string{"VAULT_TOKEN"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_TOKEN"}},
+		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT", "VAULT_TOKEN"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_TOKEN"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "VAULT_TOKEN"}},
 	}
 
 	for _, tt := range tests {

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -25,7 +25,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 		},
 	}
 
-	arg := "echo ${VAULT_CONFIG?} | base64 -d > /tmp/config.json && vault agent -config=/tmp/config.json"
+	arg := DefaultContainerArg
 
 	if a.ConfigMapName != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -33,7 +33,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("vault agent -config=%s/config-init.hcl", configVolumePath)
+		arg = fmt.Sprintf("touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -42,7 +42,7 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("vault agent -config=%s/config.hcl", configVolumePath)
+		arg = fmt.Sprintf("touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {
@@ -61,12 +61,6 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 	resources, err := a.parseResources()
 	if err != nil {
 		return corev1.Container{}, err
-	}
-
-	// Create a blank token file when namespaces are being used to avoid
-	// a bug with auto-auth, namespaces and kube auth.
-	if a.Vault.Namespace != "" {
-		arg = fmt.Sprintf("touch %s && %s", TokenFile, DefaultContainerArg)
 	}
 
 	return corev1.Container{

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -15,6 +15,7 @@ const (
 	DefaultResourceRequestCPU = "250m"
 	DefaultResourceRequestMem = "64Mi"
 	DefaultContainerArg       = "echo ${VAULT_CONFIG?} | base64 -d > /tmp/config.json && vault agent -config=/tmp/config.json"
+	DefaultAgentLogLevel      = "info"
 )
 
 // ContainerSidecar creates a new container to be added

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -63,6 +63,12 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 		return corev1.Container{}, err
 	}
 
+	// Create a blank token file when namespaces are being used to avoid
+	// a bug with auto-auth, namespaces and kube auth.
+	if a.Vault.Namespace != "" {
+		arg = fmt.Sprintf("touch %s && %s", TokenFile, DefaultContainerArg)
+	}
+
 	return corev1.Container{
 		Name:      "vault-agent",
 		Image:     a.ImageName,

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -30,15 +30,32 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	if len(container.Env) != 1 {
-		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), 1)
+	expectedEnvs := 3
+	if len(container.Env) != expectedEnvs {
+		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	if container.Env[0].Name != "VAULT_CONFIG" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[0].Name)
+	if container.Env[0].Name != "VAULT_TOKEN" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_TOKEN", container.Env[0].Name)
 	}
 
 	if container.Env[0].Value == "" {
+		t.Error("env value empty, it shouldn't be")
+	}
+
+	if container.Env[1].Name != "VAULT_LOG_LEVEL" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_LEVEL", container.Env[1].Name)
+	}
+
+	if container.Env[1].Value == "" {
+		t.Error("env value empty, it shouldn't be")
+	}
+
+	if container.Env[2].Name != "VAULT_CONFIG" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[2].Name)
+	}
+
+	if container.Env[2].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
@@ -104,8 +121,9 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	if len(container.Env) != 0 {
-		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), 0)
+	expectedEnvs := 2
+	if len(container.Env) != expectedEnvs {
+		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
 	arg := fmt.Sprintf("vault agent -config=%s/config.hcl", configVolumePath)

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -118,7 +118,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	arg := fmt.Sprintf("vault agent -config=%s/config.hcl", configVolumePath)
+	arg := fmt.Sprintf("touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
 	if container.Args[0] != arg {
 		t.Errorf("arg value wrong, should have been %s, got %s", arg, container.Args[0])
 	}

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -30,32 +30,24 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 3
+	expectedEnvs := 2
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	if container.Env[0].Name != "VAULT_TOKEN" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_TOKEN", container.Env[0].Name)
+	if container.Env[0].Name != "VAULT_LOG_LEVEL" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_LEVEL", container.Env[0].Name)
 	}
 
 	if container.Env[0].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
-	if container.Env[1].Name != "VAULT_LOG_LEVEL" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_LEVEL", container.Env[1].Name)
+	if container.Env[1].Name != "VAULT_CONFIG" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[1].Name)
 	}
 
 	if container.Env[1].Value == "" {
-		t.Error("env value empty, it shouldn't be")
-	}
-
-	if container.Env[2].Name != "VAULT_CONFIG" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[2].Name)
-	}
-
-	if container.Env[2].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
@@ -121,7 +113,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 2
+	expectedEnvs := 1
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -27,16 +27,16 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flagListen       	string // Address of Vault Server
-	flagLogLevel     	string // Log verbosity
-	flagLogFormat    	string // Log format
-	flagCertFile     	string // TLS Certificate to serve
-	flagKeyFile      	string // TLS private key to serve
-	flagAutoName     	string // MutatingWebhookConfiguration for updating
-	flagAutoHosts    	string // SANs for the auto-generated TLS cert.
-	flagVaultService 	string // Name of the Vault service
-	flagVaultImage   	string // Name of the Vault Image to use
-	flagVaultAuthPath	string // Mount Path of the Vault Kubernetes Auth Method
+	flagListen        string // Address of Vault Server
+	flagLogLevel      string // Log verbosity
+	flagLogFormat     string // Log format
+	flagCertFile      string // TLS Certificate to serve
+	flagKeyFile       string // TLS private key to serve
+	flagAutoName      string // MutatingWebhookConfiguration for updating
+	flagAutoHosts     string // SANs for the auto-generated TLS cert.
+	flagVaultService  string // Name of the Vault service
+	flagVaultImage    string // Name of the Vault Image to use
+	flagVaultAuthPath string // Mount Path of the Vault Kubernetes Auth Method
 
 	flagSet *flag.FlagSet
 


### PR DESCRIPTION
This resolves #20 by adding Vault namespace support for enterprise installations.  Additionally when debugging namespace features, I needed to increase log level.  This adds another annotation to change the Vault Agent log level (default to `info`).