### PR TITLE
Use separate annotation to specify the secret filename

### DIFF
--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -20,18 +20,41 @@ const (
 	// be set to a true or false value, as parseable by strconv.ParseBool
 	AnnotationAgentInject = "vault.hashicorp.com/agent-inject"
 
-	// AnnotationAgentInjectSecret is the key annotation that configures Vault
+	// (Deprecated) AnnotationAgentInjectSecret is the key annotation that configures Vault
 	// Agent to retrieve the secrets from Vault required by the app.  The name
 	// of the secret is any unique string after "vault.hashicorp.com/agent-inject-secret-",
 	// such as "vault.hashicorp.com/agent-inject-secret-foobar".  The value is the
 	// path in Vault where the secret is located.
+	// Deprecated because an annotation is max 63 chars in kubernetes and also does not
+	// support directory separators "/"
+	// Any attempt to create a longer name or "/" with this annotation will result in the
+	// secret not being pulled, effectively skipping this annotation
+	// This annotation will always store the file in /vaults/secrets/
+	// This annotation force lowercase the selected name eg vault.hashicorp.com/agent-inject-secret-FOOBAR
+	// will realize the secret file in /vaults/secrets/foobar
 	AnnotationAgentInjectSecret = "vault.hashicorp.com/agent-inject-secret"
+
+	// AnnotationAgentInjectLocation is the annotation that contains the valid vault path to query the
+	// secret from. Anything after the final "-" is used as a unique id to match annotation rules together
+	// use in combination with AnnotationAgentInjectFilename
+	// eg. vault.hashicorp.com/agent-inject-location-foobar: "vault/secret/place"
+	//     vault.hashicorp.com/agent-inject-filename-foobar: "directory/containing/the_secret_filename.txt"
+	AnnotationAgentInjectLocation = "vault.hashicorp.com/agent-inject-location"
+
+	// AnnotationAgentInjectFilename is the annotation that contains the filename to create on disk
+	// Anything after the final "-" is used as a unique id to match annotation rules together
+	// use in combination with AnnotationAgentInjectLocation
+	// If you specify a filename with an absolute location like "/tmp/oreo/my_secret.pem"
+	// it will get created there, if not it defaults to using a root directory of "/vault/secrets/""
+	// eg. vault.hashicorp.com/agent-inject-location-foobar: "vault/secret/place"
+	//     vault.hashicorp.com/agent-inject-filename-foobar: "directory/containing/the_secret_filename.txt"
+	AnnotationAgentInjectFilename = "vault.hashicorp.com/agent-inject-filename"
 
 	// AnnotationAgentInjectTemplate is the key annotation that configures Vault
 	// Agent what template to use for rendering the secrets.  The name
 	// of the template is any unique string after "vault.hashicorp.com/agent-inject-template-",
 	// such as "vault.hashicorp.com/agent-inject-template-foobar".  This should map
-	// to the same unique value provided in ""vault.hashicorp.com/agent-inject-secret-".
+	// to the same unique value provided in "vault.hashicorp.com/agent-inject-location-".
 	// If not provided, a default generic template is used.
 	AnnotationAgentInjectTemplate = "vault.hashicorp.com/agent-inject-template"
 
@@ -42,7 +65,7 @@ const (
 	// AnnotationAgentInjectCommand is the key annotation that configures Vault Agent
 	// to run a command after the secret is rendered. The name of the template is any
 	// unique string after "vault.hashicorp.com/agent-inject-command-". This should map
-	// to the same unique value provided in ""vault.hashicorp.com/agent-inject-secret-".
+	// to the same unique value provided in "vault.hashicorp.com/agent-inject-location-".
 	// If not provided (the default), no command is executed.
 	AnnotationAgentInjectCommand = "vault.hashicorp.com/agent-inject-command"
 
@@ -214,12 +237,22 @@ func Init(pod *corev1.Pod, image, address, authPath, namespace string, revokeOnS
 	return nil
 }
 
-// secrets parses annotations with the pattern "vault.hashicorp.com/agent-inject-secret-".
-// Everything following the final dash becomes the name of the secret,
-// and the value is the path in Vault.
+// The recommended way of specifying the filename is to use the combination of
+// "vault.hashicorp.com/agent-inject-location-" with value being the path to the secret in vault
+// "vault.hashicorp.com/agent-inject-filename-" with value being the filename to create
+// with anything following the final dash as the 'id' of that secret,
+// which is useful to match corresponding annotations together
+//
+// this method also matches and returns the Template and Command found using the
+// respective id
+//
+// (Deprecated) secrets parses annotations with the pattern "vault.hashicorp.com/agent-inject-secret-".
+// Everything following the final dash becomes the filename of the secret,
+// and the value is the path in Vault. 
+// This is deprecated because an annotation can only have max 63 chars and we cannot use "/" in the filename
 //
 // For example: "vault.hashicorp.com/agent-inject-secret-foobar: db/creds/foobar"
-// name: foobar, value: db/creds/foobar
+// filename: foobar, Path: db/creds/foobar
 func secrets(annotations map[string]string) []*Secret {
 	var secrets []*Secret
 	// First check for the token-only injection annotation
@@ -227,25 +260,19 @@ func secrets(annotations map[string]string) []*Secret {
 		annotations[fmt.Sprintf("%s-%s", AnnotationAgentInjectSecret, "token")] = TokenSecret
 		annotations[fmt.Sprintf("%s-%s", AnnotationAgentInjectTemplate, "token")] = TokenTemplate
 	}
+
 	for name, path := range annotations {
-		secretName := fmt.Sprintf("%s-", AnnotationAgentInjectSecret)
-		if strings.Contains(name, secretName) {
-			raw := strings.ReplaceAll(name, secretName, "")
-			name := strings.ToLower(raw)
-
-			if name == "" {
-				continue
-			}
-
+		name = getNameFromAnnotation(name, annotations)
+		if name != "" {
 			var template string
-			templateName := fmt.Sprintf("%s-%s", AnnotationAgentInjectTemplate, raw)
+			templateName := fmt.Sprintf("%s-%s", AnnotationAgentInjectTemplate, name)
 
 			if val, ok := annotations[templateName]; ok {
 				template = val
 			}
 
 			var command string
-			commandName := fmt.Sprintf("%s-%s", AnnotationAgentInjectCommand, raw)
+			commandName := fmt.Sprintf("%s-%s", AnnotationAgentInjectCommand, name)
 
 			if val, ok := annotations[commandName]; ok {
 				command = val
@@ -255,6 +282,39 @@ func secrets(annotations map[string]string) []*Secret {
 		}
 	}
 	return secrets
+}
+
+func getNameFromAnnotation(name string, annotations map[string]string) string {
+	secretNamePrefix := fmt.Sprintf("%s-", AnnotationAgentInjectSecret)
+	locationSecretPrefix := fmt.Sprintf("%s-", AnnotationAgentInjectLocation)
+	if strings.Contains(name, secretNamePrefix) {
+		raw := strings.ReplaceAll(name, secretNamePrefix, "")
+		name = strings.ToLower(raw) // why would we force-lowercase the filename here?
+		if len(name) >= 21 || strings.Contains(name, "/") {
+			//houston we have a problem, skip secret, can we log this somewhere?
+			return ""
+		}
+	} else if strings.Contains(name, locationSecretPrefix) {
+		uid := strings.ReplaceAll(name, locationSecretPrefix, "")
+
+		if uid == "" {
+			return ""
+		}
+
+		// get filename from AnnotationAgentInjectFilename
+		var filename string
+		filenameUid := fmt.Sprintf("%s-%s", AnnotationAgentInjectFilename, uid)
+		if val, ok := annotations[filenameUid]; ok {
+			filename = val
+		} else {
+			// if there is not the corresponding annotation, skip
+			return ""
+		}
+		name = filename
+	} else {
+		return ""
+	}
+	return name
 }
 
 func (a *Agent) inject() (bool, error) {

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -119,6 +119,7 @@ func TestSecretAnnotations(t *testing.T) {
 		{"vault.hashicorp.com/agent-inject-secret-server.crt", "creds/tls/somecert", "server.crt", "creds/tls/somecert"},
 		{"vault.hashicorp.com/agent-inject-secret", "test4", "", ""},
 		{"vault.hashicorp.com/agent-inject-secret-", "test5", "", ""},
+		{"vault.hashicorp.com/agent-inject-secret-this_is_very_long_and_would_fail_in_kubernetes", "test6", "", "test6"},
 	}
 
 	for _, tt := range tests {
@@ -130,26 +131,77 @@ func TestSecretAnnotations(t *testing.T) {
 
 		agent, err := New(pod, patches)
 		if err != nil {
+
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
 
 		if tt.expectedKey != "" {
 			if len(agent.Secrets) == 0 {
 				t.Error("Secrets length was zero, it shouldn't have been")
+			}
+			if agent.Secrets[0].Name != tt.expectedKey {
+				t.Errorf("expected %s, got %s", tt.expectedKey, agent.Secrets[0].Name)
+			}
 
-				if agent.Secrets[0].Name != tt.expectedKey {
-					t.Errorf("expected %s, got %s", tt.expectedKey, agent.Secrets[0].Name)
-				}
-
-				if agent.Secrets[0].Path != tt.expectedPath {
-					t.Errorf("expected %s, got %s", tt.expectedPath, agent.Secrets[0].Path)
-
-				}
+			if agent.Secrets[0].Path != tt.expectedPath {
+				t.Errorf("expected %s, got %s", tt.expectedPath, agent.Secrets[0].Path)
 			}
 		} else if len(agent.Secrets) > 0 {
-			t.Error("Secrets length was greater than zero, it shouldn't have been")
+			t.Errorf("Secrets length was greater than zero, it shouldn't have been %s", tt.key)
+		}
+	}
+}
+
+func TestSecretLocationFilenameAnnotations(t *testing.T) {
+	tests := []struct {
+		annotations      map[string]string
+		expectedFilename string
+		expectedLocation string
+	}{
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-location-foobar": "vault/test1",
+				"vault.hashicorp.com/agent-inject-filename-foobar": "foobar_simple_name",
+			}, "foobar_simple_name", "vault/test1",
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-location-foobar": "vault/test2",
+				"vault.hashicorp.com/agent-inject-filename-foobar": "this_is_very_long_and/would_fail_in_kubernetes/if_in_annotation",
+			}, "this_is_very_long_and/would_fail_in_kubernetes/if_in_annotation", "vault/test2",
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-location-foobar": "vault/test2",
+				"vault.hashicorp.com/agent-inject-filename-notcorresponding": "this_is_very_long_and/would_fail_in_kubernetes/if_in_annotation",
+			}, "", "",
+		},
+	}
+
+	for _, tt := range tests {
+		pod := testPod(tt.annotations)
+		var patches []*jsonpatch.JsonPatchOperation
+
+		agent, err := New(pod, patches)
+		if err != nil {
+			t.Errorf("got error, shouldn't have: %s", err)
 		}
 
+		if tt.expectedFilename != "" {
+			if len(agent.Secrets) == 0 {
+				t.Error("Secrets length was zero, it shouldn't have been")
+			}
+
+			if agent.Secrets[0].Name != tt.expectedFilename {
+				t.Errorf("expected name %s, got %s", tt.expectedFilename, agent.Secrets[0].Name)
+			}
+
+			if agent.Secrets[0].Path != tt.expectedLocation {
+				t.Errorf("expected path %s, got %s", tt.expectedLocation, agent.Secrets[0].Path)
+			}
+		} else if len(agent.Secrets) > 0 {
+			t.Errorf("Secrets length was greater than zero, it shouldn't have been",)
+		}
 	}
 }
 
@@ -193,7 +245,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 			map[string]string{
 				"vault.hashicorp.com/agent-inject-secret-foobar2":  "test1",
 				"vault.hashicorp.com/agent-inject-TEMPLATE-foobar": "foobarTemplate",
-			}, "foobar2", "foobarTemplate",
+			}, "foobar2", "",
 		},
 	}
 
@@ -214,7 +266,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 			t.Errorf("expected name %s, got %s", tt.expectedKey, agent.Secrets[0].Name)
 		}
 
-		if agent.Secrets[0].Name != tt.expectedKey {
+		if agent.Secrets[0].Template != tt.expectedTemplate {
 			t.Errorf("expected template %s, got %s", tt.expectedTemplate, agent.Secrets[0].Template)
 		}
 	}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+	"strings"
 )
 
 const (
@@ -81,9 +82,16 @@ func (a *Agent) newTemplateConfigs() []*Template {
 			template = fmt.Sprintf(DefaultTemplate, secret.Path)
 		}
 
+		destination := fmt.Sprintf("/vault/secrets/%s", secret.Name)
+
+		if strings.HasPrefix(secret.Name, "/") {
+			// it is only possible to use an absolute directory location with AnnotationAgentInjectLocation
+			destination = secret.Name
+		}
+
 		tmpl := &Template{
 			Contents:    template,
-			Destination: fmt.Sprintf("/vault/secrets/%s", secret.Name),
+			Destination: destination,
 			LeftDelim:   "{{",
 			RightDelim:  "}}",
 			Command:     secret.Command,


### PR DESCRIPTION
as per issue https://github.com/hashicorp/vault-k8s/issues/88 before this fix the secret filename was limited to 21 chars and could not contain a directory separator "/"

This fix introduces two new annotations to use together

- `vault.hashicorp.com/agent-inject-location` to specify the vault secret location
- `vault.hashicorp.com/agent-inject-filename` to specify the filename to realize

It has the advantage of allowing long filenames, include directory separators
and if the location is absolute, it will create the file there, effectively giving
the option to save outside of /vault/secrets/

Note: backwards compatibility is respected for `vault.hashicorp.com/agent-inject-secret` knowing that it has limitations:
- filename length of 21 (or 23 if not using templates)
- cannot use "/" directory separator
- filename is forced to lowercase version, I do not know the original reason for this, but kept it here