### PR TITLE
Add annotation to change init container order

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -322,6 +322,8 @@ func (a *Agent) Patch() ([]byte, error) {
 
 		// Init Containers run sequentially in Kubernetes and sometimes the order in
 		// which they run matters.  This reorders the init containers to put the agent first.
+		// For example, if an init container needed Vault secrets to work, the agent would need
+		// to run first.
 		if a.InitFirst {
 
 			// Remove all init containers from the document so we can re-add them after the agent.

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -327,7 +327,9 @@ func (a *Agent) Patch() ([]byte, error) {
 		if a.InitFirst {
 
 			// Remove all init containers from the document so we can re-add them after the agent.
-			a.Patches = append(a.Patches, removeContainers("/spec/initContainers")...)
+			if len(a.Pod.Spec.InitContainers) != 0 {
+				a.Patches = append(a.Patches, removeContainers("/spec/initContainers")...)
+			}
 
 			containers = []corev1.Container{container}
 			containers = append(containers, a.Pod.Spec.InitContainers...)

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -322,7 +322,7 @@ func (a *Agent) Patch() ([]byte, error) {
 		// which they run matters.  This reorders the init containers to put the agent first.
 		if a.InitFirst {
 
-			// Remove all init containers from the document so we can readd them after the agent.
+			// Remove all init containers from the document so we can re-add them after the agent.
 			a.Patches = append(a.Patches, removeContainers("/spec/initContainers")...)
 
 			containers := []corev1.Container{container}

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -54,7 +54,7 @@ const (
 	AnnotationAgentRequestNamespace = "vault.hashicorp.com/agent-request-namespace"
 
 	// AnnotationAgentInitFirst makes the initialization container the first container
-	// to run when a pod starts.  Default is last.
+	// to run when a pod starts. Default is last.
 	AnnotationAgentInitFirst = "vault.hashicorp.com/agent-init-first"
 
 	// AnnotationAgentPrePopulate controls whether an init container is included

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -53,6 +53,10 @@ const (
 	// originated from.
 	AnnotationAgentRequestNamespace = "vault.hashicorp.com/agent-request-namespace"
 
+	// AnnotationAgentInitFirst makes the initialization container the first container
+	// to run when a pod starts.  Default is last.
+	AnnotationAgentInitFirst = "vault.hashicorp.com/agent-init-first"
+
 	// AnnotationAgentPrePopulate controls whether an init container is included
 	// to pre-populate the shared memory volume with secrets prior to the application
 	// starting.
@@ -285,6 +289,15 @@ func (a *Agent) inject() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentInject]
 	if !ok {
 		return true, nil
+	}
+
+	return strconv.ParseBool(raw)
+}
+
+func (a *Agent) initFirst() (bool, error) {
+	raw, ok := a.Annotations[AnnotationAgentInitFirst]
+	if !ok {
+		return false, nil
 	}
 
 	return strconv.ParseBool(raw)

--- a/agent-inject/agent/patch.go
+++ b/agent-inject/agent/patch.go
@@ -55,6 +55,15 @@ func addVolumeMounts(target, mounts []corev1.VolumeMount, base string) []*jsonpa
 	return result
 }
 
+func removeContainers(path string) []*jsonpatch.JsonPatchOperation {
+	var result []*jsonpatch.JsonPatchOperation
+
+	return append(result, &jsonpatch.JsonPatchOperation{
+		Operation: "remove",
+		Path:      path,
+	})
+}
+
 func addContainers(target, containers []corev1.Container, base string) []*jsonpatch.JsonPatchOperation {
 	var result []*jsonpatch.JsonPatchOperation
 	first := len(target) == 0

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -18,6 +18,17 @@ import (
 
 func TestHandlerHandle(t *testing.T) {
 	basicSpec := corev1.PodSpec{
+		InitContainers: []corev1.Container{
+			{
+				Name: "web-init",
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "foobar",
+						MountPath: "serviceaccount/somewhere",
+					},
+				},
+			},
+		},
 		Containers: []corev1.Container{
 			{
 				Name: "web",
@@ -133,7 +144,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/initContainers",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/0/volumeMounts/-",
 				},
 				{
 					Operation: "add",
@@ -182,6 +197,14 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/1/volumeMounts/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -222,7 +245,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/initContainers",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/0/volumeMounts/-",
 				},
 				{
 					Operation: "add",
@@ -271,7 +298,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/initContainers",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/0/volumeMounts/-",
 				},
 				{
 					Operation: "add",
@@ -316,7 +347,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/initContainers",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/0/volumeMounts/-",
 				},
 				{
 					Operation: "add",
@@ -404,7 +439,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/initContainers",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/0/volumeMounts/-",
 				},
 				{
 					Operation: "add",

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -147,6 +147,51 @@ func TestHandlerHandle(t *testing.T) {
 		},
 
 		{
+			"init first ",
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			v1beta1.AdmissionRequest{
+				Namespace: "test",
+				Object: encodeRaw(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							agent.AnnotationAgentInject: "true",
+							agent.AnnotationVaultRole:   "demo",
+							agent.AnnotationAgentInitFirst: "true",
+						},
+					},
+					Spec: basicSpec,
+				}),
+			},
+			"",
+			[]jsonpatch.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts/-",
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
+				},
+			},
+		},
+
+		{
 			"configmap pod injection",
 			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{


### PR DESCRIPTION
This adds a new annotation `vault.hashicorp.com/agent-init-first` which reorders the init container array to make the Vault Agent first.  Since init containers run sequentially in order they're defined, this makes when the Vault Agent runs configurable depending on different use cases (such as init containers that need vault secrets).

Also added secret mounts to other init containers present in the pod so they can consume Vault secrets if Vault Agent runs first.

Resolves #53 .