### PR TITLE
added approle auto-auth functionality

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -93,6 +93,12 @@ type Agent struct {
 
 	// Vault is the structure holding all the Vault specific configurations.
 	Vault Vault
+
+	// AutoAuthMethod specifies whether to use default 'kubernetes' or 'approle' Vault Agent auto-auth methods
+	AutoAuthMethod string
+
+	// The name of the Kubernetes secret to lookup that contains the roleid and secretid for the approle
+	ApproleSecretName string
 }
 
 type Secret struct {
@@ -182,6 +188,8 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		ServiceAccountName: saName,
 		ServiceAccountPath: saPath,
 		Status:             pod.Annotations[AnnotationAgentStatus],
+		AutoAuthMethod:     pod.Annotations[AnnotationAgentAutoAuthMethod],
+		ApproleSecretName:  pod.Annotations[AnnotationApproleSecretName],
 		Vault: Vault{
 			Address:          pod.Annotations[AnnotationVaultService],
 			AuthPath:         pod.Annotations[AnnotationVaultAuthPath],
@@ -272,6 +280,14 @@ func ShouldInject(pod *corev1.Pod) (bool, error) {
 func (a *Agent) Patch() ([]byte, error) {
 	var patches []byte
 
+	// Add our vault-approle-secrets volume
+	if a.AutoAuthMethod == "approle" {
+		a.Patches = append(a.Patches, addVolumes(
+			a.Pod.Spec.Volumes,
+			[]corev1.Volume{a.ContainerApproleVolume()},
+			"/spec/volumes")...)
+	}
+
 	// Add our volume that will be shared by the containers
 	// for passing data in the pod.
 	a.Patches = append(a.Patches, addVolumes(
@@ -358,9 +374,23 @@ func (a *Agent) Validate() error {
 		return errors.New("no Vault image found")
 	}
 
+	if a.AutoAuthMethod == "approle" {
+		if a.ApproleSecretName == "" {
+			return errors.New("no Vault approle secret specified. Required when using 'approle' auto-auth method")
+		}
+	}
+
+	if a.AutoAuthMethod == "approle" {
+		if a.Vault.Role != "" {
+			return errors.New("AutoAuth method 'approle' and Vault Role are mutually exclusive")
+		}
+	}
+
 	if a.ConfigMapName == "" {
-		if a.Vault.Role == "" {
-			return errors.New("no Vault role found")
+		if a.AutoAuthMethod == "kubernetes" {
+			if a.Vault.Role == "" {
+				return errors.New("no Vault role found")
+			}
 		}
 
 		if a.Vault.AuthPath == "" {

--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -82,6 +82,82 @@ func TestValidate(t *testing.T) {
 			}, true,
 		},
 		{
+			// kubernetes auth-method with Vault.Role and ConfigMapName
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				ConfigMapName:      "testconfigmap",
+				AutoAuthMethod:     "kubernetes",
+				ImageName:          "test",
+				Vault: Vault{
+					Role:     "test",
+					Address:  "https://foobar.com:8200",
+					AuthPath: "test",
+				},
+			}, true,
+		},
+		{
+			// approle auth-method with ApproleSecretName and ConfigMapName
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				ConfigMapName:      "testconfigmap",
+				AutoAuthMethod:     "approle",
+				ApproleSecretName:  "foobar",
+				ImageName:          "test",
+				Vault: Vault{
+					Address:  "https://foobar.com:8200",
+					AuthPath: "test",
+				},
+			}, true,
+		},
+		{
+			// kubernetes auth-method without Vault.Role or ConfigMapName
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				AutoAuthMethod:     "kubernetes",
+				ImageName:          "test",
+				Vault: Vault{
+					Address:  "https://foobar.com:8200",
+					AuthPath: "test",
+				},
+			}, false,
+		},
+		{
+			// approle auth-method without ApproleSecretName
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				AutoAuthMethod:     "approle",
+				ImageName:          "test",
+				Vault: Vault{
+					Address:  "https://foobar.com:8200",
+					AuthPath: "test",
+				},
+			}, false,
+		},
+		{
+			// approle auth-method with Vault.Role
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				AutoAuthMethod:     "approle",
+				ApproleSecretName:  "foobar",
+				ImageName:          "test",
+				Vault: Vault{
+					Role:     "test",
+					Address:  "https://foobar.com:8200",
+					AuthPath: "test",
+				},
+			}, false,
+		},
+		{
 			Agent{
 				Namespace:          "",
 				ServiceAccountPath: "foobar",

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -67,6 +67,10 @@ const (
 	// configuration file and templates can be found.
 	AnnotationAgentConfigMap = "vault.hashicorp.com/agent-configmap"
 
+	// AnnotationAgentAutoAuthMethod specifies which auto-auth method to use in the Vault Agent.
+	// Defaults to 'kubernetes', but 'approle' is another option.
+	AnnotationAgentAutoAuthMethod = "vault.hashicorp.com/agent-auto-auth-method"
+
 	// AnnotationAgentLimitsCPU sets the CPU limit on the Vault Agent containers.
 	AnnotationAgentLimitsCPU = "vault.hashicorp.com/agent-limits-cpu"
 
@@ -146,6 +150,10 @@ const (
 	// AnnotationPreserveSecretCase if enabled will preserve the case of secret name
 	// by default the name is converted to lower case.
 	AnnotationPreserveSecretCase = "vault.hashicorp.com/preserve-secret-case"
+
+	// AnnotationApproleSecretName is the name of the secret containing the approle roleid and
+	// secretid to use in the agent when auto-auth method == approle
+	AnnotationApproleSecretName = "vault.hashicorp.com/agent-approle-secret-name"
 )
 
 // Init configures the expected annotations required to create a new instance
@@ -221,6 +229,10 @@ func Init(pod *corev1.Pod, image, address, authPath, namespace string, revokeOnS
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultLogLevel]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationVaultLogLevel] = DefaultAgentLogLevel
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentAutoAuthMethod]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentAutoAuthMethod] = DefaultAgentAutoAuth
 	}
 
 	return nil

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -459,7 +459,7 @@ func TestInitEmptyPod(t *testing.T) {
 
 	err := Init(pod, "foobar-image", "http://foobar:8200", "test", "test", true)
 	if err == nil {
-		t.Errorf("got no error, shouldn have")
+		t.Errorf("got no error, should have")
 	}
 }
 
@@ -489,6 +489,33 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 
 		if agent.Vault.Namespace != tt.expectedValue {
 			t.Errorf("expected %s, got %s", tt.expectedValue, agent.Vault.Namespace)
+		}
+	}
+}
+
+func TestAnnotationAgentAutoAuthMethod(t *testing.T) {
+	tests := []struct {
+		key           string
+		value         string
+		expectedValue string
+	}{
+		{"", "", "kubernetes"},
+		{"vault.hashicorp.com/agent-auto-auth-method", "approle", "approle"},
+	}
+
+	for _, tt := range tests {
+		annotation := map[string]string{
+			tt.key: tt.value,
+		}
+
+		pod := testPod(annotation)
+		err := Init(pod, "foobar-image", "http://foobar:8200", "test", "test", true)
+
+		if err != nil {
+			t.Errorf("got error, shouldn't have: %s", err)
+		}
+		if pod.Annotations[AnnotationAgentAutoAuthMethod] != tt.expectedValue {
+			t.Errorf("expected %s, got %s %s", tt.expectedValue, pod.Annotations[AnnotationApproleSecretName], err)
 		}
 	}
 }

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -20,6 +21,14 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 		},
 	}
 	volumeMounts = append(volumeMounts, a.ContainerVolumeMounts()...)
+
+	if a.AutoAuthMethod == "approle" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "vault-approle-secrets",
+			MountPath: approleSecretVolumePath,
+			ReadOnly:  true,
+		})
+	}
 
 	arg := DefaultContainerArg
 

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -19,6 +19,7 @@ const (
 	DefaultContainerArg       = "echo ${VAULT_CONFIG?} | base64 -d > /tmp/config.json && vault agent -config=/tmp/config.json"
 	DefaultRevokeGrace        = 5
 	DefaultAgentLogLevel      = "info"
+	DefaultAgentAutoAuth      = "kubernetes"
 )
 
 // ContainerSidecar creates a new container to be added
@@ -32,6 +33,14 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 		},
 	}
 	volumeMounts = append(volumeMounts, a.ContainerVolumeMounts()...)
+
+	if a.AutoAuthMethod == "approle" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "vault-approle-secrets",
+			MountPath: approleSecretVolumePath,
+			ReadOnly:  true,
+		})
+	}
 
 	arg := DefaultContainerArg
 

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -14,7 +14,20 @@ const (
 	tlsSecretVolumeName = "vault-tls-secrets"
 	tlsSecretVolumePath = "/vault/tls"
 	secretVolumePath    = "/vault/secrets"
+	approleSecretVolumePath = "/vault/approle"
 )
+
+// ContainerApproleVolume returns a volume to mount Approle secrets
+func (a *Agent) ContainerApproleVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "vault-approle-secrets",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: a.Annotations[AnnotationApproleSecretName],
+			},
+		},
+	}
+}
 
 func (a *Agent) getUniqueMountPaths() []string {
 	var mountPaths []string


### PR DESCRIPTION
- Adds the ability to use approle auto-auth method in the Vault agent rather than kubernetes
- Approle credentials are stored as kube secrets
- Adds the following annotations:
```
vault.hashicorp.com/agent-auto-auth-method: "approle"
vault.hashicorp.com/agent-approle-secret-name: "<approle_secret_name>"
```