### PR TITLE
[Proposal] Using default RunAsUser of the application

### DIFF
--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func testPod(annotations map[string]string) *corev1.Pod {
+	var RunAsUser int64 = 1000720000
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "foo",
@@ -22,6 +23,9 @@ func testPod(annotations map[string]string) *corev1.Pod {
 							Name:      "foobar",
 							MountPath: "serviceaccount/somewhere",
 						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &RunAsUser,
 					},
 				},
 			},

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -166,6 +166,7 @@ type AgentConfig struct {
 	RevokeOnShutdown bool
 	UserID           string
 	GroupID          string
+	SameID           bool
 }
 
 // Init configures the expected annotations required to create a new instance
@@ -244,8 +245,12 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentRunAsUser]; !ok {
+
 		if cfg.UserID == "" {
 			cfg.UserID = strconv.Itoa(DefaultAgentRunAsUser)
+		}
+		if cfg.SameID {
+			cfg.UserID = strconv.FormatInt(*pod.Spec.Containers[0].SecurityContext.RunAsUser, 10)
 		}
 		pod.ObjectMeta.Annotations[AnnotationAgentRunAsUser] = cfg.UserID
 	}
@@ -253,6 +258,9 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentRunAsGroup]; !ok {
 		if cfg.GroupID == "" {
 			cfg.GroupID = strconv.Itoa(DefaultAgentRunAsGroup)
+		}
+		if cfg.SameID {
+			cfg.GroupID = strconv.Itoa(0)
 		}
 		pod.ObjectMeta.Annotations[AnnotationAgentRunAsGroup] = cfg.GroupID
 	}

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -250,6 +250,15 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 			cfg.UserID = strconv.Itoa(DefaultAgentRunAsUser)
 		}
 		if cfg.SameID {
+			if len(pod.Spec.Containers) == 0 {
+				return errors.New("No containers found in Pod Spec")
+			}
+			if pod.Spec.Containers[0].SecurityContext == nil {
+				return errors.New("No SecurityContext found for Container 0")
+			}
+			if pod.Spec.Containers[0].SecurityContext.RunAsUser == nil {
+				return errors.New("RunAsUser is nil for Container 0's SecurityContext")
+			}
 			cfg.UserID = strconv.FormatInt(*pod.Spec.Containers[0].SecurityContext.RunAsUser, 10)
 		}
 		pod.ObjectMeta.Annotations[AnnotationAgentRunAsUser] = cfg.UserID

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -268,9 +268,6 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 		if cfg.GroupID == "" {
 			cfg.GroupID = strconv.Itoa(DefaultAgentRunAsGroup)
 		}
-		if cfg.SameID {
-			cfg.GroupID = strconv.Itoa(0)
-		}
 		pod.ObjectMeta.Annotations[AnnotationAgentRunAsGroup] = cfg.GroupID
 	}
 

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -16,7 +16,7 @@ func TestInitCanSet(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -48,7 +48,7 @@ func TestInitDefaults(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "", ""})
+	err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "", "", false})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -78,7 +78,7 @@ func TestInitError(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	err := Init(pod, AgentConfig{"image", "", "authPath", "namespace", true, "1000", "100"})
+	err := Init(pod, AgentConfig{"image", "", "authPath", "namespace", true, "1000", "100", false})
 	if err == nil {
 		t.Error("expected error no address, got none")
 	}
@@ -88,7 +88,7 @@ func TestInitError(t *testing.T) {
 		t.Errorf("expected '%s' error, got %s", errMsg, err)
 	}
 
-	err = Init(pod, AgentConfig{"image", "address", "", "namespace", true, "1000", "100"})
+	err = Init(pod, AgentConfig{"image", "address", "", "namespace", true, "1000", "100", false})
 	if err == nil {
 		t.Error("expected error no authPath, got none")
 	}
@@ -98,7 +98,7 @@ func TestInitError(t *testing.T) {
 		t.Errorf("expected '%s' error, got %s", errMsg, err)
 	}
 
-	err = Init(pod, AgentConfig{"image", "address", "authPath", "", true, "1000", "100"})
+	err = Init(pod, AgentConfig{"image", "address", "authPath", "", true, "1000", "100", false})
 	if err == nil {
 		t.Error("expected error for no namespace, got none")
 	}
@@ -134,7 +134,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOff(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
@@ -181,7 +181,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOn(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
@@ -257,7 +257,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
@@ -313,7 +313,7 @@ func TestTemplateShortcuts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+			err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -369,7 +369,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		pod := testPod(tt.annotations)
-		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
@@ -480,7 +480,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		pod := testPod(annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}
@@ -497,7 +497,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 func TestInitEmptyPod(t *testing.T) {
 	var pod *corev1.Pod
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 	if err == nil {
 		t.Errorf("got no error, should have")
 	}
@@ -522,7 +522,7 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+		err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100", false})
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
 		}

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -32,7 +32,7 @@ func TestContainerSidecarVolume(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100"})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", false})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -83,7 +83,7 @@ func TestContainerSidecar(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", false, "1000", "100"})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", false, "1000", "100", false})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -184,7 +184,7 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			pod := testPod(annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", tt.revokeFlag, "1000", "100"})
+			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", tt.revokeFlag, "1000", "100", false})
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -233,7 +233,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100"})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", false})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -588,7 +588,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 			pod := testPod(annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100"})
+			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", false})
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	RevokeOnShutdown  bool
 	UserID            string
 	GroupID           string
+	SameID            bool
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -146,6 +147,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		RevokeOnShutdown: h.RevokeOnShutdown,
 		UserID:           h.UserID,
 		GroupID:          h.GroupID,
+		SameID:           h.SameID,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestHandlerHandle(t *testing.T) {
+	var RunAsUser int64 = 1000720000
 	basicSpec := corev1.PodSpec{
 		InitContainers: []corev1.Container{
 			{
@@ -37,6 +38,9 @@ func TestHandlerHandle(t *testing.T) {
 						Name:      "foobar",
 						MountPath: "serviceaccount/somewhere",
 					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser: &RunAsUser,
 				},
 			},
 		},

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -40,6 +40,7 @@ type Command struct {
 	flagRevokeOnShutdown bool   // Revoke Vault Token on pod shutdown
 	flagRunAsUser        string // User (uid) to run Vault agent as
 	flagRunAsGroup       string // Group (gid) to run Vault agent as
+	flagRunAsSameUser    bool   // User (gid) to run Vault agent same as User (uid) application
 
 	flagSet *flag.FlagSet
 
@@ -122,6 +123,7 @@ func (c *Command) Run(args []string) int {
 		RevokeOnShutdown:  c.flagRevokeOnShutdown,
 		UserID:            c.flagRunAsUser,
 		GroupID:           c.flagRunAsGroup,
+		SameID:            c.flagRunAsSameUser,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -40,7 +40,7 @@ type Command struct {
 	flagRevokeOnShutdown bool   // Revoke Vault Token on pod shutdown
 	flagRunAsUser        string // User (uid) to run Vault agent as
 	flagRunAsGroup       string // Group (gid) to run Vault agent as
-	flagRunAsSameUser    bool   // User (gid) to run Vault agent same as User (uid) application
+	flagRunAsSameUser    bool   // Run Vault agent as the User (uid) of the first application container
 
 	flagSet *flag.FlagSet
 

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -59,6 +59,9 @@ type Specification struct {
 
 	// RunAsGroup is the AGENT_INJECT_RUN_AS_GROUP environment variable. (gid)
 	RunAsGroup string `envconfig:"AGENT_INJECT_RUN_AS_GROUP"`
+
+	// RunAsSameUser is the AGENT_INJECT_RUN_AS_SAME_USER environment variable. (gid)
+	RunAsSameUser string `envconfig:"AGENT_INJECT_RUN_AS_SAME_USER"`
 }
 
 func (c *Command) init() {
@@ -88,6 +91,8 @@ func (c *Command) init() {
 		fmt.Sprintf("User (uid) to run Vault agent as. Defaults to %d.", agent.DefaultAgentRunAsUser))
 	c.flagSet.StringVar(&c.flagRunAsGroup, "run-as-group", strconv.Itoa(agent.DefaultAgentRunAsGroup),
 		fmt.Sprintf("Group (gid) to run Vault agent as. Defaults to %d.", agent.DefaultAgentRunAsGroup))
+	c.flagSet.BoolVar(&c.flagRunAsSameUser, "run-as-same-user", true,
+		"User (gid) to run Vault agent same as User (uid) application.")
 
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -174,6 +179,13 @@ func (c *Command) parseEnvs() error {
 
 	if envs.RunAsGroup != "" {
 		c.flagRunAsGroup = envs.RunAsGroup
+	}
+
+	if envs.RunAsSameUser != "" {
+		c.flagRunAsSameUser, err = strconv.ParseBool(envs.RunAsSameUser)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -92,7 +92,8 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagRunAsGroup, "run-as-group", strconv.Itoa(agent.DefaultAgentRunAsGroup),
 		fmt.Sprintf("Group (gid) to run Vault agent as. Defaults to %d.", agent.DefaultAgentRunAsGroup))
 	c.flagSet.BoolVar(&c.flagRunAsSameUser, "run-as-same-user", true,
-		"User (gid) to run Vault agent same as User (uid) application.")
+		"Run Vault agent as the User (uid) of the first application container. "+
+		"Requires SecurityContext.RunAsUser to be set in application Pods.")
 
 	c.help = flags.Usage(help, c.flagSet)
 }

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -60,7 +60,7 @@ type Specification struct {
 	// RunAsGroup is the AGENT_INJECT_RUN_AS_GROUP environment variable. (gid)
 	RunAsGroup string `envconfig:"AGENT_INJECT_RUN_AS_GROUP"`
 
-	// RunAsSameUser is the AGENT_INJECT_RUN_AS_SAME_USER environment variable. (gid)
+	// RunAsSameUser is the AGENT_INJECT_RUN_AS_SAME_USER environment variable.
 	RunAsSameUser string `envconfig:"AGENT_INJECT_RUN_AS_SAME_USER"`
 }
 

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -152,6 +152,8 @@ func TestCommandEnvBools(t *testing.T) {
 	}{
 		{env: "AGENT_INJECT_REVOKE_ON_SHUTDOWN", value: true, cmdPtr: &cmd.flagRevokeOnShutdown},
 		{env: "AGENT_INJECT_REVOKE_ON_SHUTDOWN", value: false, cmdPtr: &cmd.flagRevokeOnShutdown},
+		{env: "AGENT_INJECT_RUN_AS_SAME_USER", value: true, cmdPtr: &cmd.flagRunAsSameUser},
+		{env: "AGENT_INJECT_RUN_AS_SAME_USER", value: false, cmdPtr: &cmd.flagRunAsSameUser},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This proposal allows running the agent sidecar container with the same RunAsUser of the application container, without worry to check which range is allowed to use.
The user range is set on the MustRunAsRange for SecurityContextConstraints or MustRunAs for PodSecurityPolicy (pre-allocated range of UIDs).
RunAsGroup with 0 which is the default of Kubernetes. 