### PR TITLE
Add annotations to configure Agent Cache

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -14,14 +14,14 @@ import (
 // TODO swap out 'github.com/mattbaird/jsonpatch' for 'github.com/evanphx/json-patch'
 
 const (
-	DefaultVaultImage      = "vault:1.3.2"
+	DefaultVaultImage      = "vault:1.4.1"
 	DefaultVaultAuthPath   = "auth/kubernetes"
 	DefaultAgentRunAsUser  = 100
 	DefaultAgentRunAsGroup = 1000
 
 	DefaultAgentCacheEnable           = "false"
 	DefaultAgentCacheUseAutoAuthToken = "true"
-	DefaultAgentCacheListenerAddress  = "127.0.0.1:8200"
+	DefaultAgentCacheListenerPort     = "8200"
 )
 
 // Agent is the top level structure holding all the
@@ -186,8 +186,8 @@ type VaultAgentCache struct {
 	// Enable configures whether the cache is enabled or not
 	Enable bool
 
-	// ListenerAddress is the address the cache should listen to
-	ListenerAddress string
+	// ListenerPort is the port the cache should listen to
+	ListenerPort string
 
 	// UseAutoAuthToken configures whether the auto auth token is used in cache requests
 	UseAutoAuthToken string
@@ -282,7 +282,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 
 	agent.VaultAgentCache = VaultAgentCache{
 		Enable:           agentCacheEnable,
-		ListenerAddress:  pod.Annotations[AnnotationAgentCacheListenerAddress],
+		ListenerPort:     pod.Annotations[AnnotationAgentCacheListenerPort],
 		UseAutoAuthToken: pod.Annotations[AnnotationAgentCacheUseAutoAuthToken],
 	}
 

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -165,8 +165,8 @@ const (
 	// auto auth token or not. Can be set to "force" to force usage of the auto-auth token
 	AnnotationAgentCacheUseAutoAuthToken = "vault.hashicorp.com/agent-cache-use-auth-auth-token"
 
-	// AnnotationAgentCacheListenerAddress configures the address the agent cache should listen on
-	AnnotationAgentCacheListenerAddress = "vault.hashicorp.com/agent-cache-listener-address"
+	// AnnotationAgentCacheListenerPort configures the port the agent cache should listen on
+	AnnotationAgentCacheListenerPort = "vault.hashicorp.com/agent-cache-listener-port"
 )
 
 type AgentConfig struct {
@@ -272,8 +272,8 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 		pod.ObjectMeta.Annotations[AnnotationAgentCacheEnable] = DefaultAgentCacheEnable
 	}
 
-	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerAddress]; !ok {
-		pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerAddress] = DefaultAgentCacheListenerAddress
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerPort]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerPort] = DefaultAgentCacheListenerPort
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken]; !ok {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -156,6 +156,17 @@ const (
 	// AnnotationPreserveSecretCase if enabled will preserve the case of secret name
 	// by default the name is converted to lower case.
 	AnnotationPreserveSecretCase = "vault.hashicorp.com/preserve-secret-case"
+
+	// AnnotationAgentCacheEnable if enabled will configure the sidecar container
+	// to enable agent caching
+	AnnotationAgentCacheEnable = "vault.hashicorp.com/agent-cache-enable"
+
+	// AnnotationAgentCacheUseAutoAuthToken configures the agent cache to use the
+	// auto auth token or not. Can be set to "force" to force usage of the auto-auth token
+	AnnotationAgentCacheUseAutoAuthToken = "vault.hashicorp.com/agent-cache-use-auth-auth-token"
+
+	// AnnotationAgentCacheListenerAddress configures the address the agent cache should listen on
+	AnnotationAgentCacheListenerAddress = "vault.hashicorp.com/agent-cache-listener-address"
 )
 
 type AgentConfig struct {
@@ -255,6 +266,18 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 			cfg.GroupID = strconv.Itoa(DefaultAgentRunAsGroup)
 		}
 		pod.ObjectMeta.Annotations[AnnotationAgentRunAsGroup] = cfg.GroupID
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheEnable]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentCacheEnable] = DefaultAgentCacheEnable
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerAddress]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentCacheListenerAddress] = DefaultAgentCacheListenerAddress
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken] = DefaultAgentCacheUseAutoAuthToken
 	}
 
 	return nil
@@ -392,5 +415,14 @@ func (a *Agent) preserveSecretCase(secretName string) (bool, error) {
 			return false, nil
 		}
 	}
+	return strconv.ParseBool(raw)
+}
+
+func (a *Agent) agentCacheEnable() (bool, error) {
+	raw, ok := a.Annotations[AnnotationAgentCacheEnable]
+	if !ok {
+		return false, nil
+	}
+
 	return strconv.ParseBool(raw)
 }

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -473,6 +473,18 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		{AnnotationAgentRunAsGroup, "0", true},
 		{AnnotationAgentRunAsGroup, "100", true},
 		{AnnotationAgentRunAsGroup, "root", false},
+
+		{AnnotationAgentCacheEnable, "true", true},
+		{AnnotationAgentCacheEnable, "false", true},
+		{AnnotationAgentCacheEnable, "TRUE", true},
+		{AnnotationAgentCacheEnable, "FALSE", true},
+		{AnnotationAgentCacheEnable, "0", true},
+		{AnnotationAgentCacheEnable, "1", true},
+		{AnnotationAgentCacheEnable, "t", true},
+		{AnnotationAgentCacheEnable, "f", true},
+		{AnnotationAgentCacheEnable, "tRuE", false},
+		{AnnotationAgentCacheEnable, "fAlSe", false},
+		{AnnotationAgentCacheEnable, "", false},
 	}
 
 	for i, tt := range tests {

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -145,7 +145,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		config.Listener = []*Listener{
 			{
 				Type:       "tcp",
-				Address:    a.VaultAgentCache.ListenerAddress,
+				Address:    fmt.Sprintf("127.0.0.1:%s", a.VaultAgentCache.ListenerPort),
 				TLSDisable: true,
 			},
 		}

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -33,12 +33,23 @@ func TestNewConfig(t *testing.T) {
 		fmt.Sprintf("%s-%s", AnnotationVaultSecretVolumePath, "different-path"): "/etc/container_environment",
 
 		"vault.hashicorp.com/agent-inject-command-bar": "pkill -HUP app",
+
+		AnnotationAgentCacheEnable: "true",
 	}
 
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+	if err != nil {
+		t.Errorf("got error initialising pod, shouldn't have: %s", err)
+	}
+
 	agent, err := New(pod, patches)
+	if err != nil {
+		t.Errorf("got error creating agent, shouldn't have: %s", err)
+	}
+
 	cfg, err := agent.newConfig(true)
 	if err != nil {
 		t.Errorf("got error creating Vault config, shouldn't have: %s", err)
@@ -89,6 +100,10 @@ func TestNewConfig(t *testing.T) {
 		t.Errorf("auto_auth mount path: expected path to be %s, got %s", annotations[AnnotationVaultAuthPath], config.AutoAuth.Method.MountPath)
 	}
 
+	if len(config.Listener) != 0 || config.Cache != nil {
+		t.Error("agent Cache should be disabled for init containers")
+	}
+
 	if len(config.Templates) != 3 {
 		t.Errorf("expected 3 template, got %d", len(config.Templates))
 	}
@@ -120,5 +135,87 @@ func TestNewConfig(t *testing.T) {
 		} else {
 			t.Error("shouldn't have got here")
 		}
+	}
+}
+
+func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
+	annotations := map[string]string{}
+
+	pod := testPod(annotations)
+	var patches []*jsonpatch.JsonPatchOperation
+
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+	if err != nil {
+		t.Errorf("got error initialising pod, shouldn't have: %s", err)
+	}
+
+	agent, err := New(pod, patches)
+	if err != nil {
+		t.Errorf("got error creating agent, shouldn't have: %s", err)
+	}
+
+	cfg, err := agent.newConfig(false)
+	if err != nil {
+		t.Errorf("got error creating Vault config, shouldn't have: %s", err)
+	}
+
+	config := &Config{}
+	if err := json.Unmarshal(cfg, config); err != nil {
+		t.Errorf("got error unmarshalling Vault config, shouldn't have: %s", err)
+	}
+
+	if len(config.Listener) != 0 || config.Cache != nil {
+		t.Error("agent Cache should be not be enabled by default")
+	}
+}
+
+func TestConfigVaultAgentCache(t *testing.T) {
+	annotations := map[string]string{
+		AnnotationAgentCacheEnable:           "true",
+		AnnotationAgentCacheUseAutoAuthToken: "force",
+		AnnotationAgentCacheListenerAddress:  "127.0.0.1:8100",
+	}
+
+	pod := testPod(annotations)
+	var patches []*jsonpatch.JsonPatchOperation
+
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:8200", "test", "test", true, "1000", "100"})
+	if err != nil {
+		t.Errorf("got error initialising pod, shouldn't have: %s", err)
+	}
+
+	agent, err := New(pod, patches)
+	if err != nil {
+		t.Errorf("got error creating agent, shouldn't have: %s", err)
+	}
+
+	cfg, err := agent.newConfig(false)
+	if err != nil {
+		t.Errorf("got error creating Vault config, shouldn't have: %s", err)
+	}
+
+	config := &Config{}
+	if err := json.Unmarshal(cfg, config); err != nil {
+		t.Errorf("got error unmarshalling Vault config, shouldn't have: %s", err)
+	}
+
+	if len(config.Listener) == 0 || config.Cache == nil {
+		t.Error("agent Cache should be enabled")
+	}
+
+	if config.Cache.UseAuthAuthToken != "force" {
+		t.Errorf("agent Cache use_auto_auth_token should be 'force', got %s instead", config.Cache.UseAuthAuthToken)
+	}
+
+	if config.Listener[0].Type != "tcp" {
+		t.Errorf("agent Cache listener type should be tcp, got %s instead", config.Listener[0].Type)
+	}
+
+	if config.Listener[0].Address != "127.0.0.1:8100" {
+		t.Errorf("agent Cache listener address should be127.0.0.1:8100, got %s", config.Listener[0].Address)
+	}
+
+	if !config.Listener[0].TLSDisable {
+		t.Error("agent Cache listener TLS should be disabled")
 	}
 }

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -173,7 +173,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 	annotations := map[string]string{
 		AnnotationAgentCacheEnable:           "true",
 		AnnotationAgentCacheUseAutoAuthToken: "force",
-		AnnotationAgentCacheListenerAddress:  "127.0.0.1:8100",
+		AnnotationAgentCacheListenerPort:     "8100",
 	}
 
 	pod := testPod(annotations)
@@ -212,7 +212,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 	}
 
 	if config.Listener[0].Address != "127.0.0.1:8100" {
-		t.Errorf("agent Cache listener address should be127.0.0.1:8100, got %s", config.Listener[0].Address)
+		t.Errorf("agent Cache listener address should be 127.0.0.1:8100, got %s", config.Listener[0].Address)
 	}
 
 	if !config.Listener[0].TLSDisable {


### PR DESCRIPTION
- TLS is always disabled because there is no way to mount arbitrary
volumes to the agent sidecar container

Fixes https://github.com/hashicorp/vault-k8s/issues/73

```
$ make test
go test -race ./...
?       github.com/hashicorp/vault-k8s  [no test files]
ok      github.com/hashicorp/vault-k8s/agent-inject     (cached)
ok      github.com/hashicorp/vault-k8s/agent-inject/agent       (cached)
ok      github.com/hashicorp/vault-k8s/helper/cert      (cached)
ok      github.com/hashicorp/vault-k8s/subcommand/injector      (cached)
?       github.com/hashicorp/vault-k8s/subcommand/version       [no test files]
?       github.com/hashicorp/vault-k8s/version  [no test files]
```