### PR TITLE
Add annotation to change secret permission

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -136,6 +136,9 @@ type Secret struct {
 	// Mount Path
 	MountPath string
 
+	// Permission is the optional permission to render the secret
+	Permission string
+
 	// Command is the optional command to run after rendering the secret.
 	Command string
 }

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -35,6 +35,14 @@ const (
 	// If not provided, a default generic template is used.
 	AnnotationAgentInjectTemplate = "vault.hashicorp.com/agent-inject-template"
 
+	// AnnotationAgentInjectPermission is the key annotation that configures Vault
+	// Agent what permission to render the secret.  The name
+	// of the template is any unique string after "vault.hashicorp.com/agent-inject-permission-",
+	// such as "vault.hashicorp.com/agent-inject-permission-foobar".  This should map
+	// to the same unique value provided in ""vault.hashicorp.com/agent-inject-secret-".
+	// If not provided, a default permission is used.
+	AnnotationAgentInjectPermission = "vault.hashicorp.com/agent-inject-permission"
+
 	// AnnotationAgentInjectToken is the annotation key for injecting the token
 	// from auth/token/lookup-self
 	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token"
@@ -352,6 +360,13 @@ func (a *Agent) secrets() []*Secret {
 				template = val
 			}
 
+			var permission string
+			permissionName := fmt.Sprintf("%s-%s", AnnotationAgentInjectPermission, raw)
+
+			if val, ok := a.Annotations[permissionName]; ok {
+				permission = val
+			}
+
 			mountPath := a.Annotations[AnnotationVaultSecretVolumePath]
 			mountPathAnnotationName := fmt.Sprintf("%s-%s", AnnotationVaultSecretVolumePath, raw)
 
@@ -366,7 +381,7 @@ func (a *Agent) secrets() []*Secret {
 				command = val
 			}
 
-			secrets = append(secrets, &Secret{Name: name, Path: path, Template: template, Command: command, MountPath: mountPath})
+			secrets = append(secrets, &Secret{Name: name, Path: path, Template: template, Permission: permission, Command: command, MountPath: mountPath})
 		}
 	}
 	return secrets

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -73,6 +73,7 @@ type Template struct {
 	LeftDelim      string `json:"left_delimiter,omitempty"`
 	RightDelim     string `json:"right_delimiter,omitempty"`
 	Command        string `json:"command,omitempty"`
+	Perms          string `json:"perms,omitempty"`
 }
 
 // Listener defines the configuration for Vault Agent Cache Listener
@@ -101,6 +102,7 @@ func (a *Agent) newTemplateConfigs() []*Template {
 			LeftDelim:   "{{",
 			RightDelim:  "}}",
 			Command:     secret.Command,
+			Perms:       secret.Permission,
 		}
 		templates = append(templates, tmpl)
 	}

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -11,28 +11,28 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	annotations := map[string]string{
-		AnnotationAgentImage:                            "vault",
-		AnnotationVaultService:                          "https://vault:8200",
-		AnnotationAgentStatus:                           "",
-		AnnotationAgentRequestNamespace:                 "foobar",
-		AnnotationVaultRole:                             "foobar",
-		AnnotationAgentPrePopulate:                      "true",
-		AnnotationAgentPrePopulateOnly:                  "true",
-		AnnotationVaultTLSServerName:                    "foobar.server",
-		AnnotationVaultCACert:                           "ca-cert",
-		AnnotationVaultCAKey:                            "ca-key",
-		AnnotationVaultClientCert:                       "client-cert",
-		AnnotationVaultClientKey:                        "client-key",
-		AnnotationVaultSecretVolumePath:                 "/vault/secrets",
-		"vault.hashicorp.com/agent-inject-secret-foo":   "db/creds/foo",
-		"vault.hashicorp.com/agent-inject-template-foo": "template foo",
-		"vault.hashicorp.com/agent-inject-secret-bar":   "db/creds/bar",
+		AnnotationAgentImage:                              "vault",
+		AnnotationVaultService:                            "https://vault:8200",
+		AnnotationAgentStatus:                             "",
+		AnnotationAgentRequestNamespace:                   "foobar",
+		AnnotationVaultRole:                               "foobar",
+		AnnotationAgentPrePopulate:                        "true",
+		AnnotationAgentPrePopulateOnly:                    "true",
+		AnnotationVaultTLSServerName:                      "foobar.server",
+		AnnotationVaultCACert:                             "ca-cert",
+		AnnotationVaultCAKey:                              "ca-key",
+		AnnotationVaultClientCert:                         "client-cert",
+		AnnotationVaultClientKey:                          "client-key",
+		AnnotationVaultSecretVolumePath:                   "/vault/secrets",
+		"vault.hashicorp.com/agent-inject-secret-foo":     "db/creds/foo",
+		"vault.hashicorp.com/agent-inject-template-foo":   "template foo",
+		"vault.hashicorp.com/agent-inject-secret-bar":     "db/creds/bar",
+		"vault.hashicorp.com/agent-inject-permission-bar": "0400",
+		"vault.hashicorp.com/agent-inject-command-bar":    "pkill -HUP app",
 
 		// render this secret at a different path
 		"vault.hashicorp.com/agent-inject-secret-different-path":                "different-path",
 		fmt.Sprintf("%s-%s", AnnotationVaultSecretVolumePath, "different-path"): "/etc/container_environment",
-
-		"vault.hashicorp.com/agent-inject-command-bar": "pkill -HUP app",
 
 		AnnotationAgentCacheEnable: "true",
 	}
@@ -131,6 +131,9 @@ func TestNewConfig(t *testing.T) {
 			}
 			if !strings.Contains(template.Command, "pkill -HUP app") {
 				t.Errorf("expected command contents to contain %s, got %s", "pkill -HUP app", template.Command)
+			}
+			if !strings.Contains(template.Perms, "0400") {
+				t.Errorf("expected perms to contain %s, got %s", "0400", template.Perms)
 			}
 		} else if strings.Contains(template.Destination, "different-path") {
 			if template.Destination != "/etc/container_environment/different-path" {


### PR DESCRIPTION
This adds a new annotation:
```yaml
vault.hashicorp.com/agent-inject-permission-
```
which changes the permission of the rendered secret.

Resolves #136 