### PR TITLE
Add extra security contexts to injected containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILD_DIR=.build
 GOOS?=linux
 GOARCH?=amd64
 BIN_NAME=$(IMAGE_NAME)_$(GOOS)_$(GOARCH)_$(VERSION)
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 .PHONY: all test build image clean 
 all: build
@@ -37,3 +38,6 @@ unit-test:
 .PHONY: mod
 mod:
 	@go mod tidy
+
+fmt:
+	gofmt -w $(GOFMT_FILES)

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -14,16 +14,18 @@ import (
 // TODO swap out 'github.com/mattbaird/jsonpatch' for 'github.com/evanphx/json-patch'
 
 const (
-	DefaultVaultImage                 = "vault:1.4.2"
-	DefaultVaultAuthPath              = "auth/kubernetes"
-	DefaultAgentRunAsUser             = 100
-	DefaultAgentRunAsGroup            = 1000
-	DefaultAgentRunAsSameUser         = false
-	DefaultAgentSetSecurityContext    = true
-	DefaultAgentReadOnlyRoot          = true
-	DefaultAgentCacheEnable           = "false"
-	DefaultAgentCacheUseAutoAuthToken = "true"
-	DefaultAgentCacheListenerPort     = "8200"
+	DefaultVaultImage                    = "vault:1.4.2"
+	DefaultVaultAuthPath                 = "auth/kubernetes"
+	DefaultAgentRunAsUser                = 100
+	DefaultAgentRunAsGroup               = 1000
+	DefaultAgentRunAsSameUser            = false
+	DefaultAgentAllowPrivilegeEscalation = false
+	DefaultAgentDropCapabilities         = "ALL"
+	DefaultAgentSetSecurityContext       = true
+	DefaultAgentReadOnlyRoot             = true
+	DefaultAgentCacheEnable              = "false"
+	DefaultAgentCacheUseAutoAuthToken    = "true"
+	DefaultAgentCacheListenerPort        = "8200"
 )
 
 // Agent is the top level structure holding all the

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -160,5 +160,9 @@ func (a *Agent) securityContext() *corev1.SecurityContext {
 		RunAsGroup:             pointerutil.Int64Ptr(a.RunAsGroup),
 		RunAsNonRoot:           pointerutil.BoolPtr(runAsNonRoot),
 		ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+		},
+		AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 	}
 }

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -530,11 +530,13 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 
 func TestContainerSidecarSecurityContext(t *testing.T) {
 	type startupOptions struct {
-		runAsUser          int64
-		runAsGroup         int64
-		runAsSameUser      bool
-		readOnlyRoot       bool
-		setSecurityContext bool
+		runAsUser                int64
+		runAsGroup               int64
+		runAsSameUser            bool
+		readOnlyRoot             bool
+		setSecurityContext       bool
+		allowPrivilegeEscalation bool
+		capabilities             []string
 	}
 	tests := []struct {
 		name                    string
@@ -546,11 +548,13 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 		{
 			name: "Runtime defaults, no annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{},
 			appSCC:      nil,
@@ -559,16 +563,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(DefaultAgentRunAsGroup),
 				RunAsNonRoot:           pointerutil.BoolPtr(true),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, non-root user and group annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser:  "1001",
@@ -580,16 +590,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(1001),
 				RunAsNonRoot:           pointerutil.BoolPtr(true),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, root user and group annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser:  "0",
@@ -601,16 +617,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(0),
 				RunAsNonRoot:           pointerutil.BoolPtr(false),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, root user and non-root group annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser:  "0",
@@ -622,16 +644,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(100),
 				RunAsNonRoot:           pointerutil.BoolPtr(false),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, non-root user and root group annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser:  "100",
@@ -643,16 +671,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(0),
 				RunAsNonRoot:           pointerutil.BoolPtr(false),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime no security context, no annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: false,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       false,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations:             map[string]string{},
 			appSCC:                  nil,
@@ -661,11 +695,13 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 		{
 			name: "Runtime no security context, but user annotation",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: false,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       false,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser: "100",
@@ -676,16 +712,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(DefaultAgentRunAsGroup),
 				RunAsNonRoot:           pointerutil.BoolPtr(true),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, but user annotation with no security context",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsUser:          "100",
@@ -697,11 +739,13 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 		{
 			name: "Runtime sameAsUser, no annotations",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      true,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            true,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{},
 			appSCC: &corev1.SecurityContext{
@@ -712,16 +756,22 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(DefaultAgentRunAsGroup),
 				RunAsNonRoot:           pointerutil.BoolPtr(true),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 		{
 			name: "Runtime defaults, sameAsUser annotation",
 			startup: startupOptions{
-				runAsUser:          DefaultAgentRunAsUser,
-				runAsGroup:         DefaultAgentRunAsGroup,
-				runAsSameUser:      DefaultAgentRunAsSameUser,
-				setSecurityContext: DefaultAgentSetSecurityContext,
-				readOnlyRoot:       DefaultAgentReadOnlyRoot,
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
 			},
 			annotations: map[string]string{
 				AnnotationAgentRunAsSameUser: "true",
@@ -734,6 +784,10 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				RunAsGroup:             pointerutil.Int64Ptr(DefaultAgentRunAsGroup),
 				RunAsNonRoot:           pointerutil.BoolPtr(true),
 				ReadOnlyRootFilesystem: pointerutil.BoolPtr(DefaultAgentReadOnlyRoot),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
+				},
+				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
 	}


### PR DESCRIPTION
Adding additional security contexts for better integration with restrictive PSP policies that require these to be set.