### PR TITLE
feat(security-context): new config CopySecurityContext

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -22,6 +22,7 @@ const (
 	DefaultAgentAllowPrivilegeEscalation = false
 	DefaultAgentDropCapabilities         = "ALL"
 	DefaultAgentSetSecurityContext       = true
+	DefaultAgentCopySecurityContext      = false
 	DefaultAgentReadOnlyRoot             = true
 	DefaultAgentCacheEnable              = "false"
 	DefaultAgentCacheUseAutoAuthToken    = "true"
@@ -123,6 +124,10 @@ type Agent struct {
 	// SetSecurityContext controls whether the injected containers have a
 	// SecurityContext set.
 	SetSecurityContext bool
+
+	// CopySecurityContext controls whether the injected containers have a
+	// SecurityContext set.
+	CopySecurityContext bool
 }
 
 type Secret struct {
@@ -288,6 +293,11 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 	}
 
 	agent.RunAsSameID, err = agent.runAsSameID(pod)
+	if err != nil {
+		return agent, err
+	}
+
+	agent.CopySecurityContext, err = agent.copySecurityContext()
 	if err != nil {
 		return agent, err
 	}

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -20,7 +20,7 @@ func TestInitCanSet(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -56,7 +56,7 @@ func TestInitDefaults(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"", "http://foobar:8200", "test", "test", true, "", "",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestInitError(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"image", "", "authPath", "namespace", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -154,7 +154,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOff(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -205,7 +205,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOn(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -285,7 +285,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -345,7 +345,7 @@ func TestTemplateShortcuts(t *testing.T) {
 			pod := testPod(tt.annotations)
 			agentConfig := AgentConfig{
 				"", "http://foobar:8200", "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -405,7 +405,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -518,6 +518,11 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		{AnnotationAgentSetSecurityContext, "secure", false},
 		{AnnotationAgentSetSecurityContext, "", false},
 
+		{AnnotationAgentCopySecurityContext, "true", true},
+		{AnnotationAgentCopySecurityContext, "false", true},
+		{AnnotationAgentCopySecurityContext, "secure", false},
+		{AnnotationAgentCopySecurityContext, "", false},
+
 		{AnnotationAgentCacheEnable, "true", true},
 		{AnnotationAgentCacheEnable, "false", true},
 		{AnnotationAgentCacheEnable, "TRUE", true},
@@ -538,7 +543,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -559,7 +564,7 @@ func TestInitEmptyPod(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -588,7 +593,7 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -42,7 +42,7 @@ func TestNewConfig(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -189,7 +189,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, DefaultAgentCopySecurityContext,
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -150,6 +150,10 @@ func (a *Agent) createLifecycle() corev1.Lifecycle {
 }
 
 func (a *Agent) securityContext() *corev1.SecurityContext {
+	if a.CopySecurityContext {
+		return a.Pod.Spec.Containers[0].SecurityContext
+	}
+	
 	runAsNonRoot := true
 
 	if a.RunAsUser == 0 || a.RunAsGroup == 0 {

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -33,7 +33,16 @@ func TestContainerSidecarVolume(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{
+		"foobar-image",
+		"http://foobar:1234",
+		"test", "test",
+		true, "1000",
+		"100",
+		DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext,
+		DefaultAgentCopySecurityContext,
+	})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -84,7 +93,18 @@ func TestContainerSidecar(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", false, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{
+		"foobar-image",
+		"http://foobar:1234",
+		"test",
+		"test",
+		false,
+		"1000",
+		"100",
+		DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext,
+		DefaultAgentCopySecurityContext,
+	})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -185,7 +205,17 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			pod := testPod(annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", tt.revokeFlag, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+			err := Init(pod, AgentConfig{
+				"foobar-image",
+				"http://foobar:1234",
+				"test", "test",
+				tt.revokeFlag,
+				"1000",
+				"100",
+				DefaultAgentRunAsSameUser,
+				DefaultAgentSetSecurityContext,
+				DefaultAgentCopySecurityContext,
+			})
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -234,7 +264,18 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{
+		"foobar-image",
+		"http://foobar:1234",
+		"test",
+		"test",
+		true,
+		"1000",
+		"100",
+		DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext,
+		DefaultAgentCopySecurityContext,
+	})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -535,6 +576,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 		runAsSameUser            bool
 		readOnlyRoot             bool
 		setSecurityContext       bool
+		copySecurityContext      bool
 		allowPrivilegeEscalation bool
 		capabilities             []string
 	}
@@ -552,6 +594,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -576,6 +619,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -603,6 +647,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -630,6 +675,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -657,6 +703,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -684,6 +731,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       false,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -699,6 +747,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       false,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -725,6 +774,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -743,6 +793,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            true,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -769,6 +820,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				runAsGroup:               DefaultAgentRunAsGroup,
 				runAsSameUser:            DefaultAgentRunAsSameUser,
 				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
 				readOnlyRoot:             DefaultAgentReadOnlyRoot,
 				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
 				capabilities:             []string{DefaultAgentDropCapabilities},
@@ -790,20 +842,85 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
 			},
 		},
+		{
+			name: "Runtime copySecurityContext, default annotation",
+			startup: startupOptions{
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
+			},
+			annotations: map[string]string{
+				AnnotationAgentCopySecurityContext: "true",
+			},
+			appSCC: &corev1.SecurityContext{
+				RunAsUser:              pointerutil.Int64Ptr(123456),
+				ReadOnlyRootFilesystem: pointerutil.BoolPtr(true),
+			},
+			expectedSecurityContext: &corev1.SecurityContext{
+				RunAsUser:              pointerutil.Int64Ptr(123456),
+				ReadOnlyRootFilesystem: pointerutil.BoolPtr(true),
+			},
+		},
+		{
+			name: "Runtime copySecurityContext, default annotation - empty security context",
+			startup: startupOptions{
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      DefaultAgentCopySecurityContext,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
+			},
+			annotations: map[string]string{
+				AnnotationAgentCopySecurityContext: "true",
+			},
+			appSCC: nil,
+			expectedSecurityContext: nil,
+		},
+		{
+			name: "Runtime defaults, copy-security-context annotation",
+			startup: startupOptions{
+				runAsUser:                DefaultAgentRunAsUser,
+				runAsGroup:               DefaultAgentRunAsGroup,
+				runAsSameUser:            DefaultAgentRunAsSameUser,
+				setSecurityContext:       DefaultAgentSetSecurityContext,
+				copySecurityContext:      true,
+				readOnlyRoot:             DefaultAgentReadOnlyRoot,
+				allowPrivilegeEscalation: DefaultAgentAllowPrivilegeEscalation,
+				capabilities:             []string{DefaultAgentDropCapabilities},
+			},
+			annotations: map[string]string{},
+			appSCC: &corev1.SecurityContext{
+				RunAsUser:              pointerutil.Int64Ptr(123456),
+				ReadOnlyRootFilesystem: pointerutil.BoolPtr(true),
+			},
+			expectedSecurityContext: &corev1.SecurityContext{
+				RunAsUser:              pointerutil.Int64Ptr(123456),
+				ReadOnlyRootFilesystem: pointerutil.BoolPtr(true),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			agentConfig := AgentConfig{
-				Image:              "foobar-image",
-				Address:            "http://foobar:1234",
-				AuthPath:           "test",
-				Namespace:          "test",
-				RevokeOnShutdown:   true,
-				UserID:             strconv.FormatInt(tt.startup.runAsUser, 10),
-				GroupID:            strconv.FormatInt(tt.startup.runAsGroup, 10),
-				SetSecurityContext: tt.startup.setSecurityContext,
-				SameID:             tt.startup.runAsSameUser,
+				Image:               "foobar-image",
+				Address:             "http://foobar:1234",
+				AuthPath:            "test",
+				Namespace:           "test",
+				RevokeOnShutdown:    true,
+				UserID:              strconv.FormatInt(tt.startup.runAsUser, 10),
+				GroupID:             strconv.FormatInt(tt.startup.runAsGroup, 10),
+				SetSecurityContext:  tt.startup.setSecurityContext,
+				CopySecurityContext: tt.startup.copySecurityContext,
+				SameID:              tt.startup.runAsSameUser,
 			}
 
 			tt.annotations[AnnotationVaultRole] = "foobar"

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -35,17 +35,18 @@ var (
 type Handler struct {
 	// RequireAnnotation means that the annotation must be given to inject.
 	// If this is false, injection is default.
-	RequireAnnotation  bool
-	VaultAddress       string
-	VaultAuthPath      string
-	ImageVault         string
-	Clientset          *kubernetes.Clientset
-	Log                hclog.Logger
-	RevokeOnShutdown   bool
-	UserID             string
-	GroupID            string
-	SameID             bool
-	SetSecurityContext bool
+	RequireAnnotation   bool
+	VaultAddress        string
+	VaultAuthPath       string
+	ImageVault          string
+	Clientset           *kubernetes.Clientset
+	Log                 hclog.Logger
+	RevokeOnShutdown    bool
+	UserID              string
+	GroupID             string
+	SameID              bool
+	SetSecurityContext  bool
+	CopySecurityContext bool
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -141,15 +142,16 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 	h.Log.Debug("setting default annotations..")
 	var patches []*jsonpatch.JsonPatchOperation
 	cfg := agent.AgentConfig{
-		Image:              h.ImageVault,
-		Address:            h.VaultAddress,
-		AuthPath:           h.VaultAuthPath,
-		Namespace:          req.Namespace,
-		RevokeOnShutdown:   h.RevokeOnShutdown,
-		UserID:             h.UserID,
-		GroupID:            h.GroupID,
-		SameID:             h.SameID,
-		SetSecurityContext: h.SetSecurityContext,
+		Image:               h.ImageVault,
+		Address:             h.VaultAddress,
+		AuthPath:            h.VaultAuthPath,
+		Namespace:           req.Namespace,
+		RevokeOnShutdown:    h.RevokeOnShutdown,
+		UserID:              h.UserID,
+		GroupID:             h.GroupID,
+		SameID:              h.SameID,
+		SetSecurityContext:  h.SetSecurityContext,
+		CopySecurityContext: h.CopySecurityContext,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -27,21 +27,22 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flagListen             string // Address of Vault Server
-	flagLogLevel           string // Log verbosity
-	flagLogFormat          string // Log format
-	flagCertFile           string // TLS Certificate to serve
-	flagKeyFile            string // TLS private key to serve
-	flagAutoName           string // MutatingWebhookConfiguration for updating
-	flagAutoHosts          string // SANs for the auto-generated TLS cert.
-	flagVaultService       string // Name of the Vault service
-	flagVaultImage         string // Name of the Vault Image to use
-	flagVaultAuthPath      string // Mount Path of the Vault Kubernetes Auth Method
-	flagRevokeOnShutdown   bool   // Revoke Vault Token on pod shutdown
-	flagRunAsUser          string // User (uid) to run Vault agent as
-	flagRunAsGroup         string // Group (gid) to run Vault agent as
-	flagRunAsSameUser      bool   // Run Vault agent as the User (uid) of the first application container
-	flagSetSecurityContext bool   // Set SecurityContext in injected containers
+	flagListen              string // Address of Vault Server
+	flagLogLevel            string // Log verbosity
+	flagLogFormat           string // Log format
+	flagCertFile            string // TLS Certificate to serve
+	flagKeyFile             string // TLS private key to serve
+	flagAutoName            string // MutatingWebhookConfiguration for updating
+	flagAutoHosts           string // SANs for the auto-generated TLS cert.
+	flagVaultService        string // Name of the Vault service
+	flagVaultImage          string // Name of the Vault Image to use
+	flagVaultAuthPath       string // Mount Path of the Vault Kubernetes Auth Method
+	flagRevokeOnShutdown    bool   // Revoke Vault Token on pod shutdown
+	flagRunAsUser           string // User (uid) to run Vault agent as
+	flagRunAsGroup          string // Group (gid) to run Vault agent as
+	flagRunAsSameUser       bool   // Run Vault agent as the User (uid) of the first application container
+	flagSetSecurityContext  bool   // Set SecurityContext in injected containers
+	flagCopySecurityContext bool   // Copy SecurityContext of first container in injected containers
 
 	flagSet *flag.FlagSet
 
@@ -115,17 +116,18 @@ func (c *Command) Run(args []string) int {
 
 	// Build the HTTP handler and server
 	injector := agentInject.Handler{
-		VaultAddress:       c.flagVaultService,
-		VaultAuthPath:      c.flagVaultAuthPath,
-		ImageVault:         c.flagVaultImage,
-		Clientset:          clientset,
-		RequireAnnotation:  true,
-		Log:                logger,
-		RevokeOnShutdown:   c.flagRevokeOnShutdown,
-		UserID:             c.flagRunAsUser,
-		GroupID:            c.flagRunAsGroup,
-		SameID:             c.flagRunAsSameUser,
-		SetSecurityContext: c.flagSetSecurityContext,
+		VaultAddress:        c.flagVaultService,
+		VaultAuthPath:       c.flagVaultAuthPath,
+		ImageVault:          c.flagVaultImage,
+		Clientset:           clientset,
+		RequireAnnotation:   true,
+		Log:                 logger,
+		RevokeOnShutdown:    c.flagRevokeOnShutdown,
+		UserID:              c.flagRunAsUser,
+		GroupID:             c.flagRunAsGroup,
+		SameID:              c.flagRunAsSameUser,
+		SetSecurityContext:  c.flagSetSecurityContext,
+		CopySecurityContext: c.flagCopySecurityContext,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -65,6 +65,9 @@ type Specification struct {
 
 	// SetSecurityContext is the AGENT_INJECT_SET_SECURITY_CONTEXT environment variable.
 	SetSecurityContext string `envconfig:"AGENT_INJECT_SET_SECURITY_CONTEXT"`
+
+	// CopySecurityContext is the AGENT_INJECT_COPY_SECURITY_CONTEXT environment variable.
+	CopySecurityContext string `envconfig:"AGENT_INJECT_COPY_SECURITY_CONTEXT"`
 }
 
 func (c *Command) init() {
@@ -100,6 +103,9 @@ func (c *Command) init() {
 			"Defaults to false.")
 	c.flagSet.BoolVar(&c.flagSetSecurityContext, "set-security-context", agent.DefaultAgentSetSecurityContext,
 		fmt.Sprintf("Set SecurityContext in injected containers. Defaults to %v.", agent.DefaultAgentSetSecurityContext),
+	)
+	c.flagSet.BoolVar(&c.flagCopySecurityContext, "copy-security-context", agent.DefaultAgentCopySecurityContext,
+		fmt.Sprintf("Copy the SecurityContext of the first container in the Pod. Defaults to %v.", agent.DefaultAgentCopySecurityContext),
 	)
 
 	c.help = flags.Usage(help, c.flagSet)
@@ -198,6 +204,13 @@ func (c *Command) parseEnvs() error {
 
 	if envs.SetSecurityContext != "" {
 		c.flagSetSecurityContext, err = strconv.ParseBool(envs.SetSecurityContext)
+		if err != nil {
+			return err
+		}
+	}
+
+	if envs.CopySecurityContext != "" {
+		c.flagCopySecurityContext, err = strconv.ParseBool(envs.CopySecurityContext)
 		if err != nil {
 			return err
 		}

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -156,6 +156,8 @@ func TestCommandEnvBools(t *testing.T) {
 		{env: "AGENT_INJECT_RUN_AS_SAME_USER", value: false, cmdPtr: &cmd.flagRunAsSameUser},
 		{env: "AGENT_INJECT_SET_SECURITY_CONTEXT", value: true, cmdPtr: &cmd.flagSetSecurityContext},
 		{env: "AGENT_INJECT_SET_SECURITY_CONTEXT", value: false, cmdPtr: &cmd.flagSetSecurityContext},
+		{env: "AGENT_INJECT_COPY_SECURITY_CONTEXT", value: true, cmdPtr: &cmd.flagCopySecurityContext},
+		{env: "AGENT_INJECT_COPY_SECURITY_CONTEXT", value: false, cmdPtr: &cmd.flagCopySecurityContext},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
CopySecurityContext copies the security context of the first container,
no matter the content. If there is no security context, then the injected
containers will not have one either.

In many cases the security context across the cluster may vary, but 
the main container will have the correct value anyway. Simply copying
that one is sufficient in many cases.