### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+<!-- Please reserve GitHub issues for bug reports and feature requests.
+
+For questions, the best place to get answers is on our [discussion forum](https://discuss.hashicorp.com/c/vault), as they will get more visibility from experienced users than the issue tracker.
+
+Please note: We take Vault's security and our users' trust very seriously. If you believe you have found a security issue in Vault Helm, _please responsibly disclose_ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
+
+-->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -23,7 +31,7 @@ Application deployment:
 # Be sure to scrub any sensitive values!
 ```
 
-Other useful info to include here: `kubectl describe deployment <app>` and `kubectl describe replicaset <app>` output.
+Other useful info to include: `kubectl describe deployment <app>` and `kubectl describe replicaset <app>` output.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Let us know about a bug!
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Deploy application annotated for vault-agent injection
+2. ...
+4. See error (vault injector logs, vault-agent logs, etc.)
+
+Application deployment:
+
+```yaml
+# Paste your application deployment yaml here.
+# Be sure to scrub any sensitive values!
+```
+
+Other useful info to include here: `kubectl describe deployment <app>` and `kubectl describe replicaset <app>` output.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+* Kubernetes version: 
+  * Distribution or cloud vendor (OpenShift, EKS, GKE, AKS, etc.):
+  * Other configuration options or runtime services (istio, etc.):
+* vault-k8s version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask a question
+    url: https://discuss.hashicorp.com/c/vault
+    about: For increased visibility, please post questions on the discussion forum, and tag with `k8s`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adding issue templates and a link to the discuss forum, similar to [vault's issue templates](https://github.com/hashicorp/vault/tree/master/.github/ISSUE_TEMPLATE).

Example: https://github.com/hashicorp/vault/issues/new/choose