### PR TITLE
Add agent-inject-containers annotation

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -383,8 +383,22 @@ func (a *Agent) Patch() ([]byte, error) {
 			"/spec/volumes")...)
 	}
 
-	//Add Volume Mounts
+	//Add Volume Mounts to desired containers
+	raw, ok := a.Pod.Annotations[AnnotationAgentInjectContainers];
+	if !ok {
+		return patches, fmt.Errorf("")
+	}
+
+	names := make(map[string]struct{})
+	for _, name := range strings.Split(raw, ",") {
+		names[name] = struct{}{}
+	}
+
 	for i, container := range a.Pod.Spec.Containers {
+		if _, ok := names[container.Name]; !ok {
+			continue
+		}
+
 		a.Patches = append(a.Patches, addVolumeMounts(
 			container.VolumeMounts,
 			a.ContainerVolumeMounts(),

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -386,7 +386,7 @@ func (a *Agent) Patch() ([]byte, error) {
 	//Add Volume Mounts to desired containers
 	raw, ok := a.Pod.Annotations[AnnotationAgentInjectContainers];
 	if !ok {
-		return patches, fmt.Errorf("")
+		return patches, fmt.Errorf("vault.hashicorp.com/agent-inject-containers annotation not found")
 	}
 
 	names := make(map[string]struct{})

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -56,6 +56,12 @@ const (
 	// If not provided (the default), no command is executed.
 	AnnotationAgentInjectCommand = "vault.hashicorp.com/agent-inject-command"
 
+	// AnnotationAgentInjectContainers is the key of the annotation that controls
+	// in which containers the secrets volume should be mounted. Multiple containers can
+	// be specificied in a comma-separated list. If not provided, the secrets volume will
+	// be mounted in all containers in the pod.
+	AnnotationAgentInjectContainers = "vault.hashicorp.com/agent-inject-containers"
+
 	// AnnotationAgentImage is the name of the Vault docker image to use.
 	AnnotationAgentImage = "vault.hashicorp.com/agent-image"
 
@@ -322,6 +328,16 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken] = DefaultAgentCacheUseAutoAuthToken
+	}
+
+	// If the AnnotationAgentInjectContainers annotation is not set, default to all containers
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentInjectContainers]; !ok {
+		containerNames := make([]string, len(pod.Spec.Containers))
+		for i, v := range pod.Spec.Containers {
+			containerNames[i] = v.Name
+		}
+
+		pod.ObjectMeta.Annotations[AnnotationAgentInjectContainers] = strings.Join(containerNames, ",")
 	}
 
 	return nil


### PR DESCRIPTION
Adds the following annotation which allows you to specify which containers will have the secrets volume mounted.
```
vault.hashicorp.com/agent-inject-containers
```
The reasoning behind this annotation is to allow for the limiting of the presence of plaintext secrets to only containers that absolutely need them.