### PR TITLE
feature: Add NAMESPACE (from downward API) to list of environment vars

### DIFF
--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -30,6 +31,16 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 			Value: a.Vault.LogLevel,
 		})
 	}
+
+	// add namespace from downward API
+	envs = append(envs, corev1.EnvVar{
+		Name: "NAMESPACE",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
+			},
+		},
+	})
 
 	if a.ConfigMapName == "" {
 		config, err := a.newConfig(init)

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -12,12 +12,12 @@ func TestContainerEnvs(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{}, []string{"VAULT_CONFIG"}},
-		{Agent{ConfigMapName: "foobar"}, []string{}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
-		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL"}},
+		{Agent{}, []string{"VAULT_CONFIG", "NAMESPACE"}},
+		{Agent{ConfigMapName: "foobar"}, []string{"NAMESPACE"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "NAMESPACE"}},
+		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT", "NAMESPACE"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "NAMESPACE"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "NAMESPACE"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For the init and sidecar, add NAMESPACE as an environment variable (obtained from downward API). 