### PR TITLE
Omit empty `Template` in configuration

### DIFF
--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	ExitAfterAuth bool         `json:"exit_after_auth"`
 	PidFile       string       `json:"pid_file"`
 	Vault         *VaultConfig `json:"vault"`
-	Templates     []*Template  `json:"template"`
+	Templates     []*Template  `json:"template,omitempty"`
 	Listener      []*Listener  `json:"listener,omitempty"`
 	Cache         *Cache       `json:"cache,omitempty"`
 }


### PR DESCRIPTION
When using agent cache only without any secrets defined via template annotations, the configuration generated has `null` for the `template` key, leading to Vault agent crashing.

For example:
```json
{
  "auto_auth": {
    "method": {
      "type": "kubernetes",
      "mount_path": "auth/kubernetes",
      "config": {
        "role": "app"
      }
    },
    "sink": [
      {
        "type": "file",
        "config": {
          "path": "/home/vault/.vault-token"
        }
      }
    ]
  },
  "exit_after_auth": false,
  "pid_file": "/home/vault/.pid",
  "vault": {
    "address": "https://vault.default.svc:8200",
    "ca_cert": "/vault/tls/ca.crt",
    "tls_server_name": "vault.core.svc.cluster.local"
  },
  "template": null,
  "listener": [
    {
      "type": "tcp",
      "address": "127.0.0.1:8200",
      "tls_disable": true
    }
  ],
  "cache": {
    "use_auto_auth_token": "true"
  }
}
```

This PR simply omits the `template` key if it's empty.