### PR TITLE
remove beta from v1 resource definition

### DIFF
--- a/deploy/injector-mutating-webhook.yaml
+++ b/deploy/injector-mutating-webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: vault-agent-injector-cfg


### PR DESCRIPTION
Should accompany https://github.com/hashicorp/vault-k8s/pull/112 

Most every platform supports > 1.16 now