### PR TITLE
Add unique home volumes for init/sidecar

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -357,7 +357,7 @@ func (a *Agent) Patch() ([]byte, error) {
 	// Add a volume for the token sink
 	a.Patches = append(a.Patches, addVolumes(
 		a.Pod.Spec.Volumes,
-		[]corev1.Volume{a.ContainerTokenVolume()},
+		a.ContainerTokenVolume(),
 		"/spec/volumes")...)
 
 	// Add our volume that will be shared by the containers

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -14,7 +14,7 @@ import (
 func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      tokenVolumeName,
+			Name:      tokenVolumeName + "-init",
 			MountPath: tokenVolumePath,
 			ReadOnly:  false,
 		},

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -60,12 +60,22 @@ func (a *Agent) ContainerVolumes() []corev1.Volume {
 
 // ContainerTokenVolume returns a volume to mount the
 // home directory where the token sink will write to.
-func (a *Agent) ContainerTokenVolume() corev1.Volume {
-	return corev1.Volume{
-		Name: tokenVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{
-				Medium: "Memory",
+func (a *Agent) ContainerTokenVolume() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: tokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+				},
+			},
+		},
+		{
+			Name: tokenVolumeName + "-init",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+				},
 			},
 		},
 	}

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -140,6 +140,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/volumes/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/volumes",
 				},
 				{
@@ -186,6 +190,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes/-",
 				},
 				{
 					Operation: "add",
@@ -245,6 +253,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/volumes/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/volumes",
 				},
 				{
@@ -295,6 +307,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes/-",
 				},
 				{
 					Operation: "add",
@@ -355,6 +371,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/volumes/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/volumes",
 				},
 				{
@@ -409,6 +429,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/volumes/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/volumes",
 				},
 				{
@@ -452,6 +476,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes/-",
 				},
 				{
 					Operation: "add",


### PR DESCRIPTION
This fixes a small bug when a Vault Agent Proxy is used to cache requests from injected agent containers.  The bug is the init container puts a token into $HOME, which is a shared memory volume.  The sidecar doesn't use this token, however, it's sent along with the request so the cache hash is calculated wrong, causing a cache miss.

Each container will now have its own memory volume for $HOME so there is nothing shared between them except the secret volumes.