### PR TITLE
Add Jira sync GitHub action

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,132 @@
+on:
+  issues:
+    types: [opened, closed, deleted, reopened]
+  pull_request:
+    types: [opened, closed, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment: # Comments on the diff
+    types: [created]
+  workflow_dispatch:
+
+
+name: Jira Sync
+
+jobs:
+  create:
+    if: (github.event_name == 'issues' || github.event_name == 'pull_request') && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    name: Create ticket
+    steps:      
+    - name: Check if community user
+      id: vault-team-role
+      run: |
+        TEAM=vault
+        ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
+        if [[ -n ${ROLE} ]]; then
+          echo "Actor ${{ github.actor }} is a ${TEAM} team member, skipping Jira ticket creation"
+        else
+          echo "Actor ${{ github.actor }} is not a ${TEAM} team member, continuing to Jira ticket creation"
+        fi
+        echo "::set-output name=role::${ROLE}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
+
+    - name: Login
+      if: ${{ !steps.vault-team-role.outputs.role }}
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+
+    - name: Create ticket
+      if: ${{ !steps.vault-team-role.outputs.role }}
+      uses: tomhjp/gh-action-jira-create@v0.1.0
+      with:
+        project: VAULT
+        issuetype: "GH Issue"
+        summary: "${{ github.repository }}: ${{ github.event.issue.title || github.event.pull_request.title }} #${{ github.event.issue.number || github.event.pull_request.number }}"
+        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }}, from ${{ github.actor }}_"
+        # customfield_10089 is issuelink
+        # customfield_10091 is team
+        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["product"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
+  
+  sync-comment:
+    if: github.event.action == 'created' || github.event.action == 'submitted'
+    runs-on: ubuntu-latest
+    name: Sync comment
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+
+    - name: Search
+      id: search
+      uses: tomhjp/gh-action-jira-search@v0.2.1
+      with:
+        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"' # cf[10089] == Issue Link custom field
+
+    - name: Sync comment
+      if: steps.search.outputs.issue
+      uses: atlassian/gajira-comment@v2.0.1
+      with:
+        issue: ${{ steps.search.outputs.issue }}
+        comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
+
+  close:
+    if: (github.event_name == 'issues' || github.event_name == 'pull_request') && (github.event.action == 'closed' || github.event.action == 'deleted')
+    runs-on: ubuntu-latest
+    name: Close ticket
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+
+    - name: Search
+      id: search
+      uses: tomhjp/gh-action-jira-search@v0.2.1
+      with:
+        # cf[10089] == Issue Link custom field
+        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+
+    - name: Close ticket
+      if: steps.search.outputs.issue
+      uses: atlassian/gajira-transition@v2.0.1
+      with:
+        issue: ${{ steps.search.outputs.issue }}
+        transition: Done
+
+  reopen:
+    if: github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    name: Reopen ticket
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+
+    - name: Search
+      id: search
+      uses: tomhjp/gh-action-jira-search@v0.2.1
+      with:
+        # cf[10089] == Issue Link custom field
+        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+
+    - name: Reopen ticket
+      if: steps.search.outputs.issue
+      uses: atlassian/gajira-transition@v2.0.1
+      with:
+        issue: ${{ steps.search.outputs.issue }}
+        transition: "To Do"

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -36,13 +36,23 @@ jobs:
         JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
 
+    - name: Set ticket type
+      if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
+      id: set-ticket-type
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+          echo "::set-output name=type::PR"
+        else
+          echo "::set-output name=type::ISS"
+        fi
+
     - name: Create ticket
       if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
       uses: tomhjp/gh-action-jira-create@v0.1.0
       with:
         project: VAULT
         issuetype: "GH Issue"
-        summary: "${{ github.repository }}: ${{ github.event.issue.title || github.event.pull_request.title }} #${{ github.event.issue.number || github.event.pull_request.number }}"
+        summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
         description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }}, from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,41 +1,35 @@
 on:
   issues:
     types: [opened, closed, deleted, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened]
-  issue_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment: # Comments on the diff
+  issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
   workflow_dispatch:
-
 
 name: Jira Sync
 
 jobs:
-  create:
-    if: (github.event_name == 'issues' || github.event_name == 'pull_request') && github.event.action == 'opened'
+  sync:
     runs-on: ubuntu-latest
-    name: Create ticket
-    steps:      
+    name: Jira sync
+    steps:
     - name: Check if community user
+      if: github.event.action == 'opened'
       id: vault-team-role
       run: |
         TEAM=vault
         ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
         if [[ -n ${ROLE} ]]; then
-          echo "Actor ${{ github.actor }} is a ${TEAM} team member, skipping Jira ticket creation"
+          echo "Actor ${{ github.actor }} is a ${TEAM} team member, skipping ticket creation"
         else
-          echo "Actor ${{ github.actor }} is not a ${TEAM} team member, continuing to Jira ticket creation"
+          echo "Actor ${{ github.actor }} is not a ${TEAM} team member"
         fi
         echo "::set-output name=role::${ROLE}"
       env:
         GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
     - name: Login
-      if: ${{ !steps.vault-team-role.outputs.role }}
       uses: atlassian/gajira-login@v2.0.0
       env:
         JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
@@ -43,89 +37,41 @@ jobs:
         JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
 
     - name: Create ticket
-      if: ${{ !steps.vault-team-role.outputs.role }}
+      if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
       uses: tomhjp/gh-action-jira-create@v0.1.0
       with:
         project: VAULT
         issuetype: "GH Issue"
         summary: "${{ github.repository }}: ${{ github.event.issue.title || github.event.pull_request.title }} #${{ github.event.issue.number || github.event.pull_request.number }}"
         description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }}, from ${{ github.actor }}_"
-        # customfield_10089 is issuelink
-        # customfield_10091 is team
-        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["product"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
-  
-  sync-comment:
-    if: github.event.action == 'created' || github.event.action == 'submitted'
-    runs-on: ubuntu-latest
-    name: Sync comment
-    steps:
-    - name: Login
-      uses: atlassian/gajira-login@v2.0.0
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+        # customfield_10089 is Issue Link custom field
+        # customfield_10091 is team custom field
+        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
 
     - name: Search
+      if: github.event.action != 'opened'
       id: search
       uses: tomhjp/gh-action-jira-search@v0.2.1
       with:
-        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"' # cf[10089] == Issue Link custom field
+        # cf[10089] is Issue Link custom field
+        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
 
     - name: Sync comment
-      if: steps.search.outputs.issue
+      if: github.event.action == 'created' && steps.search.outputs.issue
       uses: atlassian/gajira-comment@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
 
-  close:
-    if: (github.event_name == 'issues' || github.event_name == 'pull_request') && (github.event.action == 'closed' || github.event.action == 'deleted')
-    runs-on: ubuntu-latest
-    name: Close ticket
-    steps:
-    - name: Login
-      uses: atlassian/gajira-login@v2.0.0
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
-
-    - name: Search
-      id: search
-      uses: tomhjp/gh-action-jira-search@v0.2.1
-      with:
-        # cf[10089] == Issue Link custom field
-        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
-
     - name: Close ticket
-      if: steps.search.outputs.issue
+      if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue
       uses: atlassian/gajira-transition@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}
         transition: Done
 
-  reopen:
-    if: github.event.action == 'reopened'
-    runs-on: ubuntu-latest
-    name: Reopen ticket
-    steps:
-    - name: Login
-      uses: atlassian/gajira-login@v2.0.0
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
-
-    - name: Search
-      id: search
-      uses: tomhjp/gh-action-jira-search@v0.2.1
-      with:
-        # cf[10089] == Issue Link custom field
-        jql: 'project = "VAULT" and issuetype = "GH Issue" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
-
     - name: Reopen ticket
-      if: steps.search.outputs.issue
+      if: github.event.action == 'reopened' && steps.search.outputs.issue
       uses: atlassian/gajira-transition@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}


### PR DESCRIPTION
This action will sync new issues, PRs and comments across to Jira VAULT tickets. It also syncs close and reopen events.

Created from org-level template in hashicorp/.github