### PR TITLE
Allow to skip resources on agent images through annotations

### DIFF
--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -92,31 +92,42 @@ func (a *Agent) parseResources() (corev1.ResourceRequirements, error) {
 	requests := corev1.ResourceList{}
 
 	// Limits
-	cpu, err := parseQuantity(a.LimitsCPU)
-	if err != nil {
-		return resources, err
-	}
-	limits[corev1.ResourceCPU] = cpu
+	if a.LimitsCPU != "" {
+		cpu, err := parseQuantity(a.LimitsCPU)
+		if err != nil {
+			return resources, err
+		}
 
-	mem, err := parseQuantity(a.LimitsMem)
-	if err != nil {
-		return resources, err
+		limits[corev1.ResourceCPU] = cpu
 	}
-	limits[corev1.ResourceMemory] = mem
+
+	if a.LimitsMem != "" {
+		mem, err := parseQuantity(a.LimitsMem)
+		if err != nil {
+			return resources, err
+		}
+		limits[corev1.ResourceMemory] = mem
+	}
+
 	resources.Limits = limits
 
 	// Requests
-	cpu, err = parseQuantity(a.RequestsCPU)
-	if err != nil {
-		return resources, err
+	if a.RequestsCPU != "" {
+		cpu, err := parseQuantity(a.RequestsCPU)
+		if err != nil {
+			return resources, err
+		}
+		requests[corev1.ResourceCPU] = cpu
 	}
-	requests[corev1.ResourceCPU] = cpu
 
-	mem, err = parseQuantity(a.RequestsMem)
-	if err != nil {
-		return resources, err
+	if a.RequestsMem != "" {
+		mem, err := parseQuantity(a.RequestsMem)
+		if err != nil {
+			return resources, err
+		}
+		requests[corev1.ResourceMemory] = mem
 	}
-	requests[corev1.ResourceMemory] = mem
+
 	resources.Requests = requests
 
 	return resources, nil

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -261,6 +261,8 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 }
 
 func TestContainerSidecarCustomResources(t *testing.T) {
+	absent := "absent"
+
 	tests := []struct {
 		name               string
 		agent              Agent
@@ -334,6 +336,20 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsCPU: "",
 				RequestsMem: "",
 			},
+			expectedLimitCPU:   absent,
+			expectedLimitMem:   absent,
+			expectedRequestCPU: absent,
+			expectedRequestMem: absent,
+			expectedErr:        false,
+		},
+		{
+			name: "valid 0",
+			agent: Agent{
+				LimitsCPU:   "0",
+				LimitsMem:   "0",
+				RequestsCPU: "0",
+				RequestsMem: "0",
+			},
 			expectedLimitCPU:   "0",
 			expectedLimitMem:   "0",
 			expectedRequestCPU: "0",
@@ -350,8 +366,8 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 			},
 			expectedLimitCPU:   "500Mi",
 			expectedLimitMem:   "128m",
-			expectedRequestCPU: "0",
-			expectedRequestMem: "0",
+			expectedRequestCPU: absent,
+			expectedRequestMem: absent,
 			expectedErr:        false,
 		},
 		{
@@ -362,8 +378,8 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsCPU: "250Mi",
 				RequestsMem: "64m",
 			},
-			expectedLimitCPU:   "0",
-			expectedLimitMem:   "0",
+			expectedLimitCPU:   absent,
+			expectedLimitMem:   absent,
 			expectedRequestCPU: "250Mi",
 			expectedRequestMem: "64m",
 			expectedErr:        false,
@@ -377,9 +393,9 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsMem: "",
 			},
 			expectedLimitCPU:   "500Mi",
-			expectedLimitMem:   "0",
-			expectedRequestCPU: "0",
-			expectedRequestMem: "0",
+			expectedLimitMem:   absent,
+			expectedRequestCPU: absent,
+			expectedRequestMem: absent,
 			expectedErr:        false,
 		},
 		{
@@ -390,10 +406,10 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsCPU: "",
 				RequestsMem: "",
 			},
-			expectedLimitCPU:   "0",
+			expectedLimitCPU:   absent,
 			expectedLimitMem:   "128m",
-			expectedRequestCPU: "0",
-			expectedRequestMem: "0",
+			expectedRequestCPU: absent,
+			expectedRequestMem: absent,
 			expectedErr:        false,
 		},
 		{
@@ -404,10 +420,10 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsCPU: "500Mi",
 				RequestsMem: "",
 			},
-			expectedLimitCPU:   "0",
-			expectedLimitMem:   "0",
+			expectedLimitCPU:   absent,
+			expectedLimitMem:   absent,
 			expectedRequestCPU: "500Mi",
-			expectedRequestMem: "0",
+			expectedRequestMem: absent,
 			expectedErr:        false,
 		},
 		{
@@ -418,9 +434,9 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 				RequestsCPU: "",
 				RequestsMem: "128m",
 			},
-			expectedLimitCPU:   "0",
-			expectedLimitMem:   "0",
-			expectedRequestCPU: "0",
+			expectedLimitCPU:   absent,
+			expectedLimitMem:   absent,
+			expectedRequestCPU: absent,
 			expectedRequestMem: "128m",
 			expectedErr:        false,
 		},
@@ -508,20 +524,32 @@ func TestContainerSidecarCustomResources(t *testing.T) {
 			}
 
 			if !tt.expectedErr {
-				if resources.Limits.Cpu().String() != tt.expectedLimitCPU {
-					t.Errorf("expected cpu limit mismatch: wanted %s, got %s", tt.expectedLimitCPU, resources.Limits.Cpu().String())
+				cpu, exists := resources.Limits["cpu"]
+				if tt.expectedLimitCPU == absent && exists {
+					t.Errorf("expected cpu limit to not exist")
+				} else if tt.expectedLimitCPU != absent && cpu.String() != tt.expectedLimitCPU {
+					t.Errorf("expected cpu limit mismatch: wanted %s, got %s", tt.expectedLimitCPU, cpu.String())
 				}
 
-				if resources.Limits.Memory().String() != tt.expectedLimitMem {
-					t.Errorf("expected mem limit mismatch: wanted %s, got %s", tt.expectedLimitMem, resources.Limits.Memory().String())
+				mem, exists := resources.Limits["memory"]
+				if tt.expectedLimitMem == absent && exists {
+					t.Errorf("expected mem limit to not exist")
+				} else if tt.expectedLimitMem != absent && mem.String() != tt.expectedLimitMem {
+					t.Errorf("expected mem limit mismatch: wanted %s, got %s", tt.expectedLimitMem, mem.String())
 				}
 
-				if resources.Requests.Cpu().String() != tt.expectedRequestCPU {
-					t.Errorf("%s expected cpu request mismatch: wanted %s, got %s", tt.name, tt.expectedLimitCPU, resources.Requests.Cpu().String())
+				cpu, exists = resources.Requests["cpu"]
+				if tt.expectedRequestCPU == absent && exists {
+					t.Errorf("expected cpu request to not exist")
+				} else if tt.expectedRequestCPU != absent && cpu.String() != tt.expectedRequestCPU {
+					t.Errorf("expected cpu request mismatch: wanted %s, got %s", tt.expectedRequestCPU, cpu.String())
 				}
 
-				if resources.Requests.Memory().String() != tt.expectedRequestMem {
-					t.Errorf("%s expected mem request mismatch: wanted %s, got %s", tt.name, tt.expectedLimitMem, resources.Requests.Memory().String())
+				mem, exists = resources.Requests["memory"]
+				if tt.expectedRequestMem == absent && exists {
+					t.Errorf("expected mem limit to not exist")
+				} else if tt.expectedRequestMem != absent && mem.String() != tt.expectedRequestMem {
+					t.Errorf("expected mem request mismatch: wanted %s, got %s", tt.expectedRequestMem, mem.String())
 				}
 			}
 		})


### PR DESCRIPTION
Currently, it's not possible to skip creating the resource requests and limits on the injected containers via the injector. At most, you can set them to empty strings which will emit a `0` as the limits.

This pull request ensures that resource configuration can be skipped if the user has disabled them in their annotations by setting their value to `""` (empty string).

- Specifying `vault.hashicorp.com/agent-limits-cpu: ""` will skip assigning the resource limit all together
- Manually setting ``vault.hashicorp.com/agent-limits-cpu: "0"`` will still allow you to set it to 0
- No changes to the default resources when they are omitted from the annonations

## Current Behavior

The current behavior will emit a literal `0` for the limits and requests if setting them to `""`, which has some [unexpected behavior](https://github.com/kubernetes/kubernetes/issues/86244) with the scheduler and will cause the agents to get OOM killed.


```yaml
annotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/role: your-vault-role
  vault.hashicorp.com/agent-limits-cpu: ""
  vault.hashicorp.com/agent-limits-mem: ""
  vault.hashicorp.com/agent-requests-cpu: ""
  vault.hashicorp.com/agent-requests-mem: ""
```

Will result in:
```
Init Containers:
  vault-agent-init:
    Restart Count:  0
    Limits:
      cpu:     0
      memory:  0
    Requests:
      cpu:     0
```

## Updated behavior:

```yaml
annotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/role: your-vault-role
  vault.hashicorp.com/agent-limits-cpu: ""
  vault.hashicorp.com/agent-limits-mem: ""
  vault.hashicorp.com/agent-requests-cpu: ""
  vault.hashicorp.com/agent-requests-mem: ""
```

Will result in no resources set all together. As its the default for pods in Kubernetes.

### Specifying only CPU

When selecting only CPU limits, it is working as expected:
```yaml
annotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/role: your-vault-role
  vault.hashicorp.com/agent-limits-cpu: ""
  vault.hashicorp.com/agent-limits-mem: ""
  vault.hashicorp.com/agent-requests-cpu: "150m"
  vault.hashicorp.com/agent-requests-mem: "64Mi"
```
Will result in:
```
    Restart Count:  0
    Requests:
      cpu:     150m
      memory:  64Mi
    Environment:
```

## Testing

- [x] Updated the unit tests to ensure tests pass and check for the new behavior
- [x] Confirmed that the build passes locally
- [x] Manually tested in my local kubernetes cluster