### PR TITLE
Add UBI container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,16 @@ image: build
 #This target is used as part of the release pipeline in CircleCI, but can also be used to build the production image locally.
 #The released/signed linux binary will be pulled from releases.hashicorp.com instead of a local build of the binary.
 prod-image:
-	docker build -t $(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION) \
+	docker build -t $(IMAGE_TAG) \
 	--build-arg VERSION=$(VERSION) \
 	--build-arg LOCATION=$(PUBLISH_LOCATION) \
 	-f $(DOCKER_DIR)/Release.dockerfile .
+
+prod-ubi-image:
+	docker build -t $(IMAGE_TAG)_ubi \
+    --build-arg VERSION=$(VERSION) \
+    --build-arg LOCATION=$(PUBLISH_LOCATION) \
+    -f $(DOCKER_DIR)/Release.ubi.dockerfile .
 
 clean:
 	-rm -rf $(BUILD_DIR)

--- a/build/docker/Release.ubi.dockerfile
+++ b/build/docker/Release.ubi.dockerfile
@@ -1,0 +1,58 @@
+# This Dockerfile creates a production release image for the project. This
+# downloads the release from releases.hashicorp.com and therefore requires that
+# the release is published before building the Docker image.
+#
+# We don't rebuild the software because we want the exact checksums and
+# binary signatures to match the software and our builds aren't fully
+# reproducible currently.
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+
+# NAME and VERSION are the name of the software in releases.hashicorp.com
+# and the version to download. Example: NAME=consul VERSION=1.2.3.
+ARG VERSION
+ARG LOCATION
+
+LABEL maintainer="Vault Team <vault@hashicorp.com>"
+LABEL version=$VERSION
+
+# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
+ENV VERSION=$VERSION
+
+# This is the location of the releases.
+ENV LOCATION=$LOCATION
+
+# Set up certificates, base tools, and software.
+RUN set -eux && \
+    microdnf install -y ca-certificates gnupg openssl tzdata wget unzip procps shadow-utils && \
+    BUILD_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    found=''; \
+    for server in \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        hkp://keyserver.ubuntu.com:80 \
+        hkp://pgp.mit.edu:80 \
+    ; do \
+        echo "Fetching GPG key $BUILD_GPGKEY from $server"; \
+        gpg --keyserver "$server" --recv-keys "$BUILD_GPGKEY" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $BUILD_GPGKEY" && exit 1; \
+    mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget ${LOCATION}/vault-k8s/${VERSION}/vault-k8s_${VERSION}_linux_amd64.zip && \
+    wget ${LOCATION}/vault-k8s/${VERSION}/vault-k8s_${VERSION}_SHA256SUMS && \
+    wget ${LOCATION}/vault-k8s/${VERSION}/vault-k8s_${VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify vault-k8s_${VERSION}_SHA256SUMS.sig vault-k8s_${VERSION}_SHA256SUMS && \
+    grep vault-k8s_${VERSION}_linux_amd64.zip vault-k8s_${VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin vault-k8s_${VERSION}_linux_amd64.zip && \
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    gpgconf --kill dirmngr && \
+    gpgconf --kill gpg-agent && \
+    rm -rf /root/.gnupg
+
+# Create a non-root user to run the software.
+RUN groupadd --gid 1000 vault && \
+    adduser --uid 100 --system -g vault vault && \
+    usermod -a -G root vault
+
+USER 100
+ENTRYPOINT ["/bin/vault-k8s"]


### PR DESCRIPTION
This PR adds UBI flavored container image for Vault K8s.  I notice the Makefile wasn't using a variable created specifically for the image tag, so I swapped it.

The image tag for UBI has `_ubi` appended to it, similar to how we do `ent` images in the Vault project.