### PR TITLE
Add metadata labels and license to images

### DIFF
--- a/build/docker/Release.dockerfile
+++ b/build/docker/Release.dockerfile
@@ -12,6 +12,8 @@ FROM alpine:latest
 ARG VERSION
 ARG LOCATION
 
+# Additional metadata labels used by container registries, platforms
+# and certification scanners.
 LABEL name="Vault K8s" \
       maintainer="Vault Team <vault@hashicorp.com>" \
       vendor="HashiCorp" \

--- a/build/docker/Release.dockerfile
+++ b/build/docker/Release.dockerfile
@@ -12,14 +12,21 @@ FROM alpine:latest
 ARG VERSION
 ARG LOCATION
 
-LABEL maintainer="Vault Team <vault@hashicorp.com>"
-LABEL version=$VERSION
+LABEL name="Vault K8s" \
+      maintainer="Vault Team <vault@hashicorp.com>" \
+      vendor="HashiCorp" \
+      version=$VERSION \
+      release=$VERSION \
+      summary="The Vault-K8s binary includes first-class integrations between Vault and Kubernetes." \
+      description="Vault-K8s includes first-class integrations between Vault and Kuberentes. Integrations include the Vault Agent Injector mutating admission webhook."
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV VERSION=$VERSION
 
 # This is the location of the releases.
 ENV LOCATION=$LOCATION
+
+COPY LICENSE /licenses/mozilla.txt
 
 # Create a non-root user to run the software.
 RUN addgroup vault && \

--- a/build/docker/Release.ubi.dockerfile
+++ b/build/docker/Release.ubi.dockerfile
@@ -12,6 +12,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 ARG VERSION
 ARG LOCATION
 
+# Additional metadata labels used by container registries, platforms
+# and certification scanners.
 LABEL name="Vault K8s" \
       maintainer="Vault Team <vault@hashicorp.com>" \
       vendor="HashiCorp" \

--- a/build/docker/Release.ubi.dockerfile
+++ b/build/docker/Release.ubi.dockerfile
@@ -22,6 +22,8 @@ LABEL name="Vault K8s" \
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV VERSION=$VERSION
+
+# This is the location of the releases.
 ENV LOCATION=$LOCATION
 
 # Copy license for Red Hat certification.

--- a/build/docker/Release.ubi.dockerfile
+++ b/build/docker/Release.ubi.dockerfile
@@ -8,18 +8,24 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
-# and the version to download. Example: NAME=consul VERSION=1.2.3.
+# and the version to download.
 ARG VERSION
 ARG LOCATION
 
-LABEL maintainer="Vault Team <vault@hashicorp.com>"
-LABEL version=$VERSION
+LABEL name="Vault K8s" \
+      maintainer="Vault Team <vault@hashicorp.com>" \
+      vendor="HashiCorp" \
+      version=$VERSION \
+      release=$VERSION \
+      summary="The Vault-K8s binary includes first-class integrations between Vault and Kubernetes." \
+      description="Vault-K8s includes first-class integrations between Vault and Kuberentes. Integrations include the Vault Agent Injector mutating admission webhook."
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV VERSION=$VERSION
-
-# This is the location of the releases.
 ENV LOCATION=$LOCATION
+
+# Copy license for Red Hat certification.
+COPY LICENSE /licenses/mozilla.txt
 
 # Set up certificates, base tools, and software.
 RUN set -eux && \


### PR DESCRIPTION
This PR adds additional labels to the Dockerfiles. The metadata and license are used by certification and vulnerability scanners (specifically Red Hat).