### PR TITLE
Update dev to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 Features:
 * Added `extra-secret` annotation for mounting kube-secrets: [GH-119](https://github.com/hashicorp/vault-k8s/pull/119)
-* Added UBI container image: [GH-183](https://github.com/hashicorp/vault-k8s/pull/183)
 
 Improvements:
 * Resource limits and requests can be disabled via annotation: [GH-174](https://github.com/hashicorp/vault-k8s/pull/174)

--- a/build/docker/Dev.dockerfile
+++ b/build/docker/Dev.dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ARG VERSION=0.5.0
+ARG VERSION=0.6.0
 
 RUN addgroup vault && \
     adduser -S -G vault vault


### PR DESCRIPTION
This updates the dev Docker image to 0.6.0 because the CI pipeline currently doesn't do this. Additionally, UBI isn't released yet, so I removed it from the CL. I will add it back after the release as an Unreleased feature.