### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.12
+    - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     working_directory: /go/src/github.com/hashicorp/vault-k8s
     steps:
     - checkout

--- a/build/docker/Dev.dockerfile
+++ b/build/docker/Dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.mirror.hashicorp.services/alpine:latest
 
 ARG VERSION=0.6.0
 

--- a/build/docker/Release.dockerfile
+++ b/build/docker/Release.dockerfile
@@ -5,7 +5,7 @@
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:latest
+FROM docker.mirror.hashicorp.services/alpine:latest
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 