### PR TITLE
Modified the DefaultTemplate to only showcase key:value from the prop…

### DIFF
--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
+	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data.data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
 	TokenTemplate   = "{{ with secret \"auth/token/lookup-self\" }}{{ .Data.id }}\n{{ end }}"
 	TokenSecret     = "auth/token/lookup-self"
 	PidFile         = "/home/vault/.pid"


### PR DESCRIPTION
…er location.

Currently
data: map[]
metadata: map[created_time:2020-11-14T18:58:09.86960569Z deletion_time: destroyed:false version:1]

is being passed, which makes it incredibly difficult to parse the actual file properly, due to the fact some values could have `Spaces` within them, or even : which would make it alittle harder to properly parse.

Expected Output:

Key:Value
Key:Value
Key:Value

Current Output:
data: map[key:value key:value key:value]
metadata: map[created_time:2020-11-14T18:58:09.86960569Z deletion_time: destroyed:false version:1]

Reason for Edit:

This causes parsing this file to be extremely difficult. Currently I have made a single change adding only a `.data` too the DefaultTemplate. This will allow for a simple Regex Statement, and really easy parsing. 

I Hope this is accepted, <3 Thank you for your time in reading this.