### PR TITLE
Add Vault agent annotation 'log-format'

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -123,8 +123,8 @@ type Agent struct {
 	// SetSecurityContext controls whether the injected containers have a
 	// SecurityContext set.
 	SetSecurityContext bool
-  
- 	// ExtraSecret is the Kubernetes secret to mount as a volume in the Vault agent container
+
+	// ExtraSecret is the Kubernetes secret to mount as a volume in the Vault agent container
 	// which can be referenced by the Agent config for secrets. Mounted at /vault/custom/
 	ExtraSecret string
 }
@@ -185,6 +185,9 @@ type Vault struct {
 	// LogLevel sets the Vault Agent log level.  Defaults to info.
 	LogLevel string
 
+	// LogFormat sets the Vault Agent log format.  Defaults to standard.
+	LogFormat string
+
 	// Namespace is the Vault namespace to prepend to secret paths.
 	Namespace string
 
@@ -243,6 +246,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 			ClientMaxRetries: pod.Annotations[AnnotationVaultClientMaxRetries],
 			ClientTimeout:    pod.Annotations[AnnotationVaultClientTimeout],
 			LogLevel:         pod.Annotations[AnnotationVaultLogLevel],
+			LogFormat:        pod.Annotations[AnnotationVaultLogFormat],
 			Namespace:        pod.Annotations[AnnotationVaultNamespace],
 			Role:             pod.Annotations[AnnotationVaultRole],
 			TLSSecret:        pod.Annotations[AnnotationVaultTLSSecret],

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -165,6 +165,9 @@ const (
 	// AnnotationVaultLogLevel sets the Vault Agent log level.
 	AnnotationVaultLogLevel = "vault.hashicorp.com/log-level"
 
+	// AnnotationVaultLogFormat sets the Vault Agent log format.
+	AnnotationVaultLogFormat = "vault.hashicorp.com/log-format"
+
 	// AnnotationVaultRole specifies the role to be used for the Kubernetes auto-auth
 	// method.
 	AnnotationVaultRole = "vault.hashicorp.com/role"
@@ -283,6 +286,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultLogLevel]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationVaultLogLevel] = DefaultAgentLogLevel
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultLogFormat]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationVaultLogFormat] = DefaultAgentLogFormat
 	}
 
 	if _, securityContextIsSet = pod.ObjectMeta.Annotations[AnnotationAgentSetSecurityContext]; !securityContextIsSet {

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -28,6 +29,13 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_LOG_LEVEL",
 			Value: a.Vault.LogLevel,
+		})
+	}
+
+	if a.Vault.LogFormat != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "VAULT_LOG_FORMAT",
+			Value: a.Vault.LogFormat,
 		})
 	}
 

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -18,6 +18,7 @@ const (
 	DefaultContainerArg       = "echo ${VAULT_CONFIG?} | base64 -d > /home/vault/config.json && vault agent -config=/home/vault/config.json"
 	DefaultRevokeGrace        = 5
 	DefaultAgentLogLevel      = "info"
+	DefaultAgentLogFormat     = "standard"
 )
 
 // ContainerSidecar creates a new container to be added


### PR DESCRIPTION
This add the annotation `vault.hashicorp.com/log-format` . This enables us to have json output for the vault agent.