### PR TITLE
Add support for injecting HTTPS_PROXY env var in agent containers

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -160,6 +160,9 @@ type Vault struct {
 	// Address is the Vault service address.
 	Address string
 
+	// ProxyAddress is the proxy service address to use when talking to the Vault service.
+	ProxyAddress string
+
 	// AuthPath is the Mount Path of Vault Kubernetes Auth Method.
 	AuthPath string
 
@@ -244,6 +247,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		CopyVolumeMounts:   pod.Annotations[AnnotationAgentCopyVolumeMounts],
 		Vault: Vault{
 			Address:          pod.Annotations[AnnotationVaultService],
+			ProxyAddress:     pod.Annotations[AnnotationProxyAddress],
 			AuthPath:         pod.Annotations[AnnotationVaultAuthPath],
 			CACert:           pod.Annotations[AnnotationVaultCACert],
 			CAKey:            pod.Annotations[AnnotationVaultCAKey],

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -129,6 +129,9 @@ const (
 	// user but will be set by a flag on the deployment.
 	AnnotationVaultService = "vault.hashicorp.com/service"
 
+	// AnnotationProxyAddress is the HTTP proxy to use when talking to the Vault server.
+	AnnotationProxyAddress = "vault.hashicorp.com/proxy-address"
+
 	// AnnotationVaultTLSSkipVerify allows users to configure verifying TLS
 	// when communicating with Vault.
 	AnnotationVaultTLSSkipVerify = "vault.hashicorp.com/tls-skip-verify"
@@ -211,6 +214,7 @@ type AgentConfig struct {
 	GroupID            string
 	SameID             bool
 	SetSecurityContext bool
+	ProxyAddress       string
 }
 
 // Init configures the expected annotations required to create a new instance
@@ -248,6 +252,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultAuthPath]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationVaultAuthPath] = cfg.AuthPath
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationProxyAddress]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationProxyAddress] = cfg.ProxyAddress
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentImage]; !ok {

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -20,7 +20,7 @@ func TestInitCanSet(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -35,6 +35,7 @@ func TestInitCanSet(t *testing.T) {
 		{annotationKey: AnnotationAgentImage, annotationValue: "foobar-image"},
 		{annotationKey: AnnotationAgentRequestNamespace, annotationValue: "test"},
 		{annotationKey: AnnotationAgentRevokeOnShutdown, annotationValue: "true"},
+		{annotationKey: AnnotationProxyAddress, annotationValue: "http://proxy:3128"},
 	}
 
 	for _, tt := range tests {
@@ -56,7 +57,7 @@ func TestInitDefaults(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"", "http://foobar:8200", "test", "test", true, "", "",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -90,7 +91,7 @@ func TestInitError(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"image", "", "authPath", "namespace", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -154,7 +155,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOff(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -205,7 +206,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOn(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -292,7 +293,7 @@ func TestSecretLocationFileAnnotations(t *testing.T) {
 
 			agentConfig := AgentConfig{
 				"", "http://foobar:8200", "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -377,7 +378,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -437,7 +438,7 @@ func TestTemplateShortcuts(t *testing.T) {
 			pod := testPod(tt.annotations)
 			agentConfig := AgentConfig{
 				"", "http://foobar:8200", "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -497,7 +498,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -630,7 +631,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -651,7 +652,7 @@ func TestInitEmptyPod(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -680,7 +681,7 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -30,6 +30,7 @@ type Config struct {
 // Vault contains configuration for connecting to Vault servers
 type VaultConfig struct {
 	Address       string `json:"address"`
+	ProxyAddress  string `json:"proxy_adress"`
 	CACert        string `json:"ca_cert,omitempty"`
 	CAPath        string `json:"ca_path,omitempty"`
 	TLSSkipVerify bool   `json:"tls_skip_verify,omitempty"`
@@ -119,6 +120,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		ExitAfterAuth: init,
 		Vault: &VaultConfig{
 			Address:       a.Vault.Address,
+			ProxyAddress:  a.Vault.ProxyAddress,
 			CACert:        a.Vault.CACert,
 			CAPath:        a.Vault.CAKey,
 			ClientCert:    a.Vault.ClientCert,

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -30,7 +30,6 @@ type Config struct {
 // Vault contains configuration for connecting to Vault servers
 type VaultConfig struct {
 	Address       string `json:"address"`
-	ProxyAddress  string `json:"proxy_adress"`
 	CACert        string `json:"ca_cert,omitempty"`
 	CAPath        string `json:"ca_path,omitempty"`
 	TLSSkipVerify bool   `json:"tls_skip_verify,omitempty"`
@@ -120,7 +119,6 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		ExitAfterAuth: init,
 		Vault: &VaultConfig{
 			Address:       a.Vault.Address,
-			ProxyAddress:  a.Vault.ProxyAddress,
 			CACert:        a.Vault.CACert,
 			CAPath:        a.Vault.CAKey,
 			ClientCert:    a.Vault.ClientCert,

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -24,6 +24,7 @@ func TestNewConfig(t *testing.T) {
 		AnnotationVaultClientCert:                       "client-cert",
 		AnnotationVaultClientKey:                        "client-key",
 		AnnotationVaultSecretVolumePath:                 "/vault/secrets",
+		AnnotationProxyAddress:                          "http://proxy:3128",
 		"vault.hashicorp.com/agent-inject-secret-foo":   "db/creds/foo",
 		"vault.hashicorp.com/agent-inject-template-foo": "template foo",
 		"vault.hashicorp.com/agent-inject-secret-bar":   "db/creds/bar",
@@ -42,7 +43,7 @@ func TestNewConfig(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -102,6 +103,10 @@ func TestNewConfig(t *testing.T) {
 
 	if config.AutoAuth.Method.MountPath != annotations[AnnotationVaultAuthPath] {
 		t.Errorf("auto_auth mount path: expected path to be %s, got %s", annotations[AnnotationVaultAuthPath], config.AutoAuth.Method.MountPath)
+	}
+
+	if config.Vault.ProxyAddress != annotations[AnnotationProxyAddress] {
+		t.Errorf("proxy_address: expected %s, got %s", annotations[AnnotationProxyAddress], config.Vault.ProxyAddress)
 	}
 
 	if len(config.Listener) != 0 || config.Cache != nil {
@@ -208,7 +213,7 @@ func TestFilePathAndName(t *testing.T) {
 
 			agentConfig := AgentConfig{
 				"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -240,7 +245,7 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -279,7 +284,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext,
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -105,10 +105,6 @@ func TestNewConfig(t *testing.T) {
 		t.Errorf("auto_auth mount path: expected path to be %s, got %s", annotations[AnnotationVaultAuthPath], config.AutoAuth.Method.MountPath)
 	}
 
-	if config.Vault.ProxyAddress != annotations[AnnotationProxyAddress] {
-		t.Errorf("proxy_address: expected %s, got %s", annotations[AnnotationProxyAddress], config.Vault.ProxyAddress)
-	}
-
 	if len(config.Listener) != 0 || config.Cache != nil {
 		t.Error("agent Cache should be disabled for init containers")
 	}

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -39,6 +39,13 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 		})
 	}
 
+	if a.Vault.ProxyAddress != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: a.Vault.ProxyAddress,
+		})
+	}
+
 	if a.ConfigMapName == "" {
 		config, err := a.newConfig(init)
 		if err != nil {

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -17,7 +17,7 @@ func TestContainerEnvs(t *testing.T) {
 		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
 		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
 	}
 
 	for _, tt := range tests {

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -39,7 +39,7 @@ func TestContainerSidecarVolume(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -100,7 +100,7 @@ func TestContainerSidecar(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", false, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", false, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128"})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -115,7 +115,7 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 3
+	expectedEnvs := 4
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
@@ -132,12 +132,16 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_FORMAT", container.Env[1].Name)
 	}
 
+	if container.Env[2].Name != "HTTPS_PROXY" {
+		t.Errorf("env name wrong, should have been %s, got %s", "HTTPS_PROXY", container.Env[2].Name)
+	}
+
 	if container.Env[1].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
-	if container.Env[2].Name != "VAULT_CONFIG" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[2].Name)
+	if container.Env[3].Name != "VAULT_CONFIG" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[3].Name)
 	}
 
 	if container.Env[2].Value == "" {
@@ -209,7 +213,7 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			pod := testPod(annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", tt.revokeFlag, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", tt.revokeFlag, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -258,7 +262,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext})
+	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -856,6 +860,7 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 				GroupID:            strconv.FormatInt(tt.startup.runAsGroup, 10),
 				SetSecurityContext: tt.startup.setSecurityContext,
 				SameID:             tt.startup.runAsSameUser,
+				ProxyAddress:       "",
 			}
 
 			tt.annotations[AnnotationVaultRole] = "foobar"

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -38,6 +38,7 @@ type Handler struct {
 	RequireAnnotation  bool
 	VaultAddress       string
 	VaultAuthPath      string
+	ProxyAddress       string
 	ImageVault         string
 	Clientset          *kubernetes.Clientset
 	Log                hclog.Logger
@@ -144,6 +145,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		Image:              h.ImageVault,
 		Address:            h.VaultAddress,
 		AuthPath:           h.VaultAuthPath,
+		ProxyAddress:       h.ProxyAddress,
 		Namespace:          req.Namespace,
 		RevokeOnShutdown:   h.RevokeOnShutdown,
 		UserID:             h.UserID,

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -125,7 +125,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"basic pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), ProxyAddress: "http://proxy:3128"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -40,6 +40,7 @@ type Command struct {
 	flagAutoName           string // MutatingWebhookConfiguration for updating
 	flagAutoHosts          string // SANs for the auto-generated TLS cert.
 	flagVaultService       string // Name of the Vault service
+	flagProxyAddress       string // HTTP proxy address used to talk to the Vault service
 	flagVaultImage         string // Name of the Vault Image to use
 	flagVaultAuthPath      string // Mount Path of the Vault Kubernetes Auth Method
 	flagRevokeOnShutdown   bool   // Revoke Vault Token on pod shutdown
@@ -144,6 +145,7 @@ func (c *Command) Run(args []string) int {
 	injector := agentInject.Handler{
 		VaultAddress:       c.flagVaultService,
 		VaultAuthPath:      c.flagVaultAuthPath,
+		ProxyAddress:       c.flagProxyAddress,
 		ImageVault:         c.flagVaultImage,
 		Clientset:          clientset,
 		RequireAnnotation:  true,

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -45,6 +45,9 @@ type Specification struct {
 	// VaultAddr is the AGENT_INJECT_VAULT_ADDR environment variable.
 	VaultAddr string `split_words:"true"`
 
+	// ProxyAddr is the AGENT_INJECT_PROXY_ADDR environment variable.
+	ProxyAddr string `split_words:"true"`
+
 	// VaultImage is the AGENT_INJECT_VAULT_IMAGE environment variable.
 	VaultImage string `split_words:"true"`
 
@@ -92,6 +95,8 @@ func (c *Command) init() {
 		fmt.Sprintf("Docker image for Vault. Defaults to %q.", agent.DefaultVaultImage))
 	c.flagSet.StringVar(&c.flagVaultService, "vault-address", "",
 		"Address of the Vault server.")
+	c.flagSet.StringVar(&c.flagProxyAddress, "proxy-address", "",
+		"HTTP proxy address used to talk to the Vault service.")
 	c.flagSet.StringVar(&c.flagVaultAuthPath, "vault-auth-path", agent.DefaultVaultAuthPath,
 		fmt.Sprintf("Mount Path of the Vault Kubernetes Auth Method. Defaults to %q.", agent.DefaultVaultAuthPath))
 	c.flagSet.BoolVar(&c.flagRevokeOnShutdown, "revoke-on-shutdown", false,
@@ -177,6 +182,10 @@ func (c *Command) parseEnvs() error {
 
 	if envs.VaultAddr != "" {
 		c.flagVaultService = envs.VaultAddr
+	}
+
+	if envs.ProxyAddr != "" {
+		c.flagProxyAddress = envs.ProxyAddr
 	}
 
 	if envs.VaultAuthPath != "" {

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -113,6 +113,7 @@ func TestCommandEnvs(t *testing.T) {
 	}{
 		{env: "AGENT_INJECT_LISTEN", value: ":8080", cmdPtr: &cmd.flagListen},
 		{env: "AGENT_INJECT_VAULT_ADDR", value: "http://vault:8200", cmdPtr: &cmd.flagVaultService},
+		{env: "AGENT_INJECT_PROXY_ADDR", value: "http://proxy:3128", cmdPtr: &cmd.flagProxyAddress},
 		{env: "AGENT_INJECT_VAULT_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagVaultAuthPath},
 		{env: "AGENT_INJECT_VAULT_IMAGE", value: "vault:1.6.2", cmdPtr: &cmd.flagVaultImage},
 		{env: "AGENT_INJECT_TLS_KEY_FILE", value: "server.key", cmdPtr: &cmd.flagKeyFile},


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**

This PR aims to add to the injector the ability of setting the `HTTPS_PROXY` environment variable in the init/sidecar containers in order to allow requests to Vault to be made via a proxy.

**References:**

Fixes: #205

**Notes:**

If the reviewers feel there are tests missing, please let me know! I may have missed something.

I'll try to run this version of the injector in a test cluster to validate the workflow, but in the mean time, feel free to comment.