### PR TITLE
Add annotation to copy volume mounts from existing container

### DIFF
--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -22,6 +22,11 @@ func testPod(annotations map[string]string) *corev1.Pod {
 							Name:      "foobar",
 							MountPath: "serviceaccount/somewhere",
 						},
+						{
+							Name:      "tobecopied",
+							MountPath: "/etc/somewhereelse",
+							ReadOnly:  false,
+						},
 					},
 				},
 			},

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -191,6 +191,11 @@ const (
 
 	// AnnotationAgentCacheListenerPort configures the port the agent cache should listen on
 	AnnotationAgentCacheListenerPort = "vault.hashicorp.com/agent-cache-listener-port"
+
+	// AnnotationAgentCopyVolumeMounts is the name of the container or init container
+	// in the Pod whose volume mounts should be copied onto the Vault Agent init and
+	// sidecar containers. Ignores any Kubernetes service account token mounts.
+	AnnotationAgentCopyVolumeMounts = "vault.hashicorp.com/agent-copy-volume-mounts"
 )
 
 type AgentConfig struct {

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -34,6 +34,10 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 		})
 	}
 
+	if a.CopyVolumeMounts != "" {
+		volumeMounts = append(volumeMounts, a.copyVolumeMounts(a.CopyVolumeMounts)...)
+	}
+
 	arg := DefaultContainerArg
 
 	if a.ConfigMapName != "" {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -45,6 +45,10 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 		})
 	}
 
+	if a.CopyVolumeMounts != "" {
+		volumeMounts = append(volumeMounts, a.copyVolumeMounts(a.CopyVolumeMounts)...)
+	}
+
 	arg := DefaultContainerArg
 
 	if a.ConfigMapName != "" {

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -31,6 +31,9 @@ func TestContainerSidecarVolume(t *testing.T) {
 
 		// Test adding an extra secret from Kube secrets for reference by Agent config
 		fmt.Sprintf("%s", AnnotationAgentExtraSecret): "extrasecret",
+
+		// Test copying volume mounts from an existing container in the Pod to the agent container
+		fmt.Sprintf("%s", AnnotationAgentCopyVolumeMounts): "foobar",
 	}
 
 	pod := testPod(annotations)
@@ -48,8 +51,8 @@ func TestContainerSidecarVolume(t *testing.T) {
 
 	container, err := agent.ContainerSidecar()
 
-	// One token volume mount, one config volume mount and two secrets volume mounts
-	require.Equal(t, 5, len(container.VolumeMounts))
+	// One token volume mount, one config volume mount, two secrets volume mounts, and one mount copied from main container
+	require.Equal(t, 6, len(container.VolumeMounts))
 
 	require.Equal(
 		t,
@@ -78,6 +81,11 @@ func TestContainerSidecarVolume(t *testing.T) {
 				Name:      extraSecretVolumeName,
 				MountPath: extraSecretVolumePath,
 				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      "tobecopied",
+				MountPath: "/etc/somewhereelse",
+				ReadOnly:  false,
 			},
 		},
 		container.VolumeMounts,


### PR DESCRIPTION
This PR introduces the following annotation: `vault.hashicorp.com/agent-copy-volume-mounts`, whose value is expected to be the name of container (or init container) in the original pod spec whose volume mounts are to be copied into the Vault Agent init/sidecar containers. Volume mounts whose paths include the string `serviceaccount` are ignored so we don't end up copying K8s service account token mounts (ie, `/var/run/secrets/kubernetes.io/serviceaccount`).

The reasoning behind this feature: At Salesforce, we inject all pods with X.509 certs via SPIFFE at runtime that end up in `emptyDir` volumes. We'd like to use the [Vault Agent Auto-Auth Cert Method](https://www.vaultproject.io/docs/agent/autoauth/methods/cert) with these certs; our Vaults already [require mTLS](https://www.vaultproject.io/docs/configuration/listener/tcp#tls_require_and_verify_client_cert) and use the [TLS Certificates Auth Method](https://www.vaultproject.io/docs/auth/cert) against this PKI, so having these volumes mounted to the Vault Agent's init and sidecar containers is required.

Regarding Auto-Auth via the Cert Method - I've got a separate branch that generalizes the injector to support all Auth Methods (#213). We're currently successfully running a build of the injector with these features in our dev environment.

Let me know how I can help to get this merged. Thanks! ☄️ 