### PR TITLE
Enable persistent agent caching

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -232,6 +232,9 @@ type VaultAgentCache struct {
 	// UseAutoAuthToken configures whether the auto auth token is used in cache requests
 	UseAutoAuthToken string
 
+	// Persist marks whether persistent caching is enabled or not
+	Persist bool
+
 	// ExitOnErr configures whether the agent will exit on an error while
 	// restoring the persistent cache
 	ExitOnErr bool
@@ -351,6 +354,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		UseAutoAuthToken: pod.Annotations[AnnotationAgentCacheUseAutoAuthToken],
 		ExitOnErr:        agentCacheExitOnErr,
 	}
+	agent.VaultAgentCache.Persist = agent.agentCachePersist()
 
 	return agent, nil
 }
@@ -431,7 +435,7 @@ func (a *Agent) Patch() ([]byte, error) {
 	}
 
 	// Add persistent cache volume if configured
-	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+	if a.VaultAgentCache.Persist {
 		a.Patches = append(a.Patches, addVolumes(
 			a.Pod.Spec.Volumes,
 			[]corev1.Volume{a.cacheVolume()},

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -338,12 +338,12 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		return agent, err
 	}
 
-	agentCacheEnable, err := agent.agentCacheEnable()
+	agentCacheEnable, err := agent.cacheEnable()
 	if err != nil {
 		return agent, err
 	}
 
-	agentCacheExitOnErr, err := agent.agentCacheExitOnErr()
+	agentCacheExitOnErr, err := agent.cacheExitOnErr()
 	if err != nil {
 		return agent, err
 	}
@@ -353,8 +353,8 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		ListenerPort:     pod.Annotations[AnnotationAgentCacheListenerPort],
 		UseAutoAuthToken: pod.Annotations[AnnotationAgentCacheUseAutoAuthToken],
 		ExitOnErr:        agentCacheExitOnErr,
+		Persist:          agent.cachePersist(agentCacheEnable),
 	}
-	agent.VaultAgentCache.Persist = agent.agentCachePersist()
 
 	return agent, nil
 }

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -549,7 +549,7 @@ func (a *Agent) setSecurityContext() (bool, error) {
 	return strconv.ParseBool(raw)
 }
 
-func (a *Agent) agentCacheEnable() (bool, error) {
+func (a *Agent) cacheEnable() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentCacheEnable]
 	if !ok {
 		return false, nil
@@ -558,14 +558,14 @@ func (a *Agent) agentCacheEnable() (bool, error) {
 	return strconv.ParseBool(raw)
 }
 
-func (a *Agent) agentCachePersist() bool {
-	if a.VaultAgentCache.Enable && a.PrePopulate && !a.PrePopulateOnly {
+func (a *Agent) cachePersist(cacheEnabled bool) bool {
+	if cacheEnabled && a.PrePopulate && !a.PrePopulateOnly {
 		return true
 	}
 	return false
 }
 
-func (a *Agent) agentCacheExitOnErr() (bool, error) {
+func (a *Agent) cacheExitOnErr() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentCacheExitOnErr]
 	if !ok {
 		return false, nil

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -558,6 +558,13 @@ func (a *Agent) agentCacheEnable() (bool, error) {
 	return strconv.ParseBool(raw)
 }
 
+func (a *Agent) agentCachePersist() bool {
+	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+		return true
+	}
+	return false
+}
+
 func (a *Agent) agentCacheExitOnErr() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentCacheExitOnErr]
 	if !ok {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -559,7 +559,7 @@ func (a *Agent) agentCacheEnable() (bool, error) {
 }
 
 func (a *Agent) agentCachePersist() bool {
-	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+	if a.VaultAgentCache.Enable && a.PrePopulate && !a.PrePopulateOnly {
 		return true
 	}
 	return false

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -205,6 +205,10 @@ const (
 	// AnnotationAgentCacheListenerPort configures the port the agent cache should listen on
 	AnnotationAgentCacheListenerPort = "vault.hashicorp.com/agent-cache-listener-port"
 
+	// AnnotationAgentCacheExitOnErr configures whether the agent will exit on an
+	// error while restoring the persistent cache
+	AnnotationAgentCacheExitOnErr = "vault.hashicorp.com/agent-cache-exit-on-err"
+
 	// AnnotationAgentCopyVolumeMounts is the name of the container or init container
 	// in the Pod whose volume mounts should be copied onto the Vault Agent init and
 	// sidecar containers. Ignores any Kubernetes service account token mounts.
@@ -361,6 +365,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentCacheUseAutoAuthToken] = DefaultAgentCacheUseAutoAuthToken
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheExitOnErr]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentCacheExitOnErr] = strconv.FormatBool(DefaultAgentCacheExitOnErr)
 	}
 
 	return nil
@@ -543,6 +551,15 @@ func (a *Agent) setSecurityContext() (bool, error) {
 
 func (a *Agent) agentCacheEnable() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentCacheEnable]
+	if !ok {
+		return false, nil
+	}
+
+	return strconv.ParseBool(raw)
+}
+
+func (a *Agent) agentCacheExitOnErr() (bool, error) {
+	raw, ok := a.Annotations[AnnotationAgentCacheExitOnErr]
 	if !ok {
 		return false, nil
 	}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -155,14 +155,15 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		Templates: a.newTemplateConfigs(),
 	}
 
+	cacheListener := []*Listener{
+		{
+			Type:       "tcp",
+			Address:    fmt.Sprintf("127.0.0.1:%s", a.VaultAgentCache.ListenerPort),
+			TLSDisable: true,
+		},
+	}
 	if a.VaultAgentCache.Persist {
-		config.Listener = []*Listener{
-			{
-				Type:       "tcp",
-				Address:    fmt.Sprintf("127.0.0.1:%s", a.VaultAgentCache.ListenerPort),
-				TLSDisable: true,
-			},
-		}
+		config.Listener = cacheListener
 		config.Cache = &Cache{
 			UseAutoAuthToken: a.VaultAgentCache.UseAutoAuthToken,
 			Persist: &CachePersist{
@@ -170,6 +171,11 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 				Path:      cacheVolumePath,
 				ExitOnErr: a.VaultAgentCache.ExitOnErr,
 			},
+		}
+	} else if a.VaultAgentCache.Enable && !a.PrePopulateOnly && !init {
+		config.Listener = cacheListener
+		config.Cache = &Cache{
+			UseAutoAuthToken: a.VaultAgentCache.UseAutoAuthToken,
 		}
 	}
 

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -155,7 +155,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		Templates: a.newTemplateConfigs(),
 	}
 
-	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+	if a.VaultAgentCache.Persist {
 		config.Listener = []*Listener{
 			{
 				Type:       "tcp",

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -57,7 +57,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 		})
 	}
 
-	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+	if a.VaultAgentCache.Persist {
 		volumeMounts = append(volumeMounts, a.cacheVolumeMount())
 	}
 

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -57,6 +57,10 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 		})
 	}
 
+	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+		volumeMounts = append(volumeMounts, a.cacheVolumeMount())
+	}
+
 	envs, err := a.ContainerEnvVars(true)
 	if err != nil {
 		return corev1.Container{}, err

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -69,6 +69,11 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 		})
 	}
 
+	// TODO(tvoran): replace this with one bool on Agent{}?
+	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+		volumeMounts = append(volumeMounts, a.cacheVolumeMount())
+	}
+
 	envs, err := a.ContainerEnvVars(false)
 	if err != nil {
 		return corev1.Container{}, err

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -69,8 +69,7 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 		})
 	}
 
-	// TODO(tvoran): replace this with one bool on Agent{}?
-	if a.VaultAgentCache.Enable && !a.PrePopulateOnly {
+	if a.VaultAgentCache.Persist {
 		volumeMounts = append(volumeMounts, a.cacheVolumeMount())
 	}
 

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
 	"github.com/mattbaird/jsonpatch"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestContainerSidecarVolume(t *testing.T) {
@@ -884,6 +886,97 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 			}
 
 			require.Equal(t, tt.expectedSecurityContext, container.SecurityContext)
+		})
+	}
+}
+
+func TestContainerCache(t *testing.T) {
+	cacheMount := []corev1.VolumeMount{
+		{
+			Name:      cacheVolumeName,
+			MountPath: cacheVolumePath,
+			ReadOnly:  false,
+		},
+	}
+	cacheVolumePatch := []*jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/volumes",
+			Value: []v1.Volume{
+				{
+					Name: "vault-agent-cache",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium: "Memory",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                   string
+		annotations            map[string]string
+		expectCacheVolAndMount bool
+	}{
+		{
+			"cache enabled",
+			map[string]string{
+				AnnotationVaultRole:        "role",
+				AnnotationAgentCacheEnable: "true",
+			},
+			true,
+		},
+		{
+			"cache disabled",
+			map[string]string{
+				AnnotationVaultRole:        "role",
+				AnnotationAgentCacheEnable: "false",
+			},
+			false,
+		},
+		{
+			"only init container",
+			map[string]string{
+				AnnotationVaultRole:            "role",
+				AnnotationAgentCacheEnable:     "true",
+				AnnotationAgentPrePopulateOnly: "true",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := testPod(tt.annotations)
+			var patches []*jsonpatch.JsonPatchOperation
+
+			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
+			require.NoError(t, err)
+
+			agent, err := New(pod, patches)
+			require.NoError(t, err)
+			err = agent.Validate()
+			require.NoError(t, err)
+
+			init, err := agent.ContainerInitSidecar()
+			require.NoError(t, err)
+
+			sidecar, err := agent.ContainerSidecar()
+			require.NoError(t, err)
+
+			_, err = agent.Patch()
+			require.NoError(t, err)
+
+			if tt.expectCacheVolAndMount {
+				assert.Subset(t, init.VolumeMounts, cacheMount)
+				assert.Subset(t, sidecar.VolumeMounts, cacheMount)
+				assert.Subset(t, agent.Patches, cacheVolumePatch)
+			} else {
+				assert.NotSubset(t, init.VolumeMounts, cacheMount)
+				assert.NotSubset(t, sidecar.VolumeMounts, cacheMount)
+				assert.NotSubset(t, agent.Patches, cacheVolumePatch)
+			}
 		})
 	}
 }

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -945,6 +945,15 @@ func TestContainerCache(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"only sidecar container",
+			map[string]string{
+				AnnotationVaultRole:        "role",
+				AnnotationAgentCacheEnable: "true",
+				AnnotationAgentPrePopulate: "false",
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -19,6 +19,8 @@ const (
 	secretVolumePath       = "/vault/secrets"
 	extraSecretVolumeName  = "extra-secrets"
 	extraSecretVolumePath  = "/vault/custom"
+	cacheVolumeName        = "vault-agent-cache"
+	cacheVolumePath        = "/vault/agent-cache"
 )
 
 func (a *Agent) getUniqueMountPaths() []string {
@@ -153,4 +155,23 @@ func (a *Agent) ContainerVolumeMounts() []corev1.VolumeMount {
 		)
 	}
 	return volumeMounts
+}
+
+func (a *Agent) cacheVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: cacheVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: "Memory",
+			},
+		},
+	}
+}
+
+func (a *Agent) cacheVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      cacheVolumeName,
+		MountPath: cacheVolumePath,
+		ReadOnly:  false,
+	}
 }


### PR DESCRIPTION
Adds support for persistent agent caching introduced in https://github.com/hashicorp/vault/pull/10938

Controlled by the "vault.hashicorp.com/agent-cache-enable" annotation, with a few caveats:

If "vault.hashicorp.com/agent-cache-enable": "true",
* ...and if init and sidecar enabled, persistent caching enabled
* ...and if sidecar only, just memory caching without persistence enabled
* ...and if init only, no caching at all

When persistent caching is enabled, a `vault-agent-cache` memory volume is mounted at `/vault/agent-cache` on the init and sidecar containers.

Also adds an annotation "vault.hashicorp.com/agent-cache-exit-on-err", which corresponds to the exit_on_err config setting introduced in https://github.com/hashicorp/vault/pull/10938. Controls whether the agent will exit on an error while restoring the persistent cache.