### PR TITLE
Add flag and annotation to override default template

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -38,6 +38,10 @@ type Agent struct {
 	// configure the Vault Agent container.
 	Annotations map[string]string
 
+	// DefaultTemplate is the default template to be used when
+	// no custom template is specified via annotations.
+	DefaultTemplate string
+
 	// ImageName is the name of the Vault image to use for the
 	// sidecar container.
 	ImageName string
@@ -248,6 +252,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 		Annotations:        pod.Annotations,
 		ConfigMapName:      pod.Annotations[AnnotationAgentConfigMap],
 		ImageName:          pod.Annotations[AnnotationAgentImage],
+		DefaultTemplate:    pod.Annotations[AnnotationAgentInjectDefaultTemplate],
 		LimitsCPU:          pod.Annotations[AnnotationAgentLimitsCPU],
 		LimitsMem:          pod.Annotations[AnnotationAgentLimitsMem],
 		Namespace:          pod.Annotations[AnnotationAgentRequestNamespace],
@@ -346,6 +351,14 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 	agentCacheExitOnErr, err := agent.cacheExitOnErr()
 	if err != nil {
 		return agent, err
+	}
+
+	agent.DefaultTemplate = strings.ToLower(agent.DefaultTemplate)
+	switch agent.DefaultTemplate {
+	case "map":
+	case "json":
+	default:
+		return agent, fmt.Errorf("invalid default template type: %s", agent.DefaultTemplate)
 	}
 
 	agent.VaultAgentCache = VaultAgentCache{

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -48,7 +48,7 @@ const (
 	// AnnotationAgentInjectDefaultTemplate sets the default template type. Possible values
 	// are "json" and "map".
 	AnnotationAgentInjectDefaultTemplate = "vault.hashicorp.com/agent-inject-default-template"
-  
+
 	// AnnotationAgentInjectTemplateFile is the optional key annotation that configures Vault
 	// Agent what template on disk to use for rendering the secrets.  The name
 	// of the template is any unique string after "vault.hashicorp.com/agent-inject-template-file-",

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -45,6 +45,10 @@ const (
 	// If not provided, a default generic template is used.
 	AnnotationAgentInjectTemplate = "vault.hashicorp.com/agent-inject-template"
 
+	// AnnotationAgentInjectDefaultTemplate sets the default template type. Possible values
+	// are "json" and "map".
+	AnnotationAgentInjectDefaultTemplate = "vault.hashicorp.com/agent-inject-default-template"
+
 	// AnnotationAgentInjectToken is the annotation key for injecting the token
 	// from auth/token/lookup-self
 	AnnotationAgentInjectToken = "vault.hashicorp.com/agent-inject-token"
@@ -227,6 +231,7 @@ type AgentConfig struct {
 	SameID             bool
 	SetSecurityContext bool
 	ProxyAddress       string
+	DefaultTemplate    string
 }
 
 // Init configures the expected annotations required to create a new instance
@@ -369,6 +374,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentCacheExitOnErr]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentCacheExitOnErr] = strconv.FormatBool(DefaultAgentCacheExitOnErr)
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentInjectDefaultTemplate]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentInjectDefaultTemplate] = cfg.DefaultTemplate
 	}
 
 	return nil

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -20,7 +20,7 @@ func TestInitCanSet(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestInitDefaults(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "", "",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestInitError(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"image", "", DefaultVaultAuthType, "authPath", "namespace", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -155,7 +155,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOff(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -206,7 +206,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOn(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -293,7 +293,7 @@ func TestSecretLocationFileAnnotations(t *testing.T) {
 
 			agentConfig := AgentConfig{
 				"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -378,7 +378,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -438,7 +438,7 @@ func TestTemplateShortcuts(t *testing.T) {
 			pod := testPod(tt.annotations)
 			agentConfig := AgentConfig{
 				"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -498,7 +498,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -631,7 +631,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -652,7 +652,7 @@ func TestInitEmptyPod(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err == nil {
@@ -681,7 +681,7 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -841,7 +841,7 @@ func TestAuthConfigAnnotations(t *testing.T) {
 
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {
@@ -854,5 +854,89 @@ func TestAuthConfigAnnotations(t *testing.T) {
 		}
 
 		require.Equal(t, agent.Vault.AuthConfig, tt.expectedAuthConfig, "expected AuthConfig %v, got %v", tt.expectedAuthConfig, agent.Vault.AuthConfig)
+	}
+}
+
+func TestDefaultTemplateOverride(t *testing.T) {
+	tests := []struct {
+		annotations   map[string]string
+		expectedValue string
+		expectedErr   bool
+	}{
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "json",
+			},
+			"json",
+			false,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "JSON",
+			},
+			"json",
+			false,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "map",
+			},
+			"map",
+			false,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "MAP",
+			},
+			"map",
+			false,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "foobar",
+			},
+			"",
+			true,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "jsn",
+			},
+			"",
+			true,
+		},
+		{
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-default-template": "",
+			},
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		pod := testPod(tt.annotations)
+		var patches []*jsonpatch.JsonPatchOperation
+
+		agentConfig := AgentConfig{
+			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
+			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
+		}
+		err := Init(pod, agentConfig)
+		if err != nil {
+			t.Errorf("got error, shouldn't have: %s", err)
+		}
+
+		agent, err := New(pod, patches)
+		if err != nil && !tt.expectedErr {
+			t.Errorf("got error, shouldn't have: %s", err)
+		} else if err == nil && tt.expectedErr {
+			t.Error("got no error, should have")
+		}
+
+		if !tt.expectedErr {
+			require.Equal(t, agent.DefaultTemplate, tt.expectedValue,
+				"expected %v, got %v", tt.expectedValue, agent.DefaultTemplate)
+		}
 	}
 }

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -27,7 +27,7 @@ func basicAgentConfig() AgentConfig {
 		SameID:             DefaultAgentRunAsSameUser,
 		SetSecurityContext: DefaultAgentSetSecurityContext,
 		ProxyAddress:       "http://proxy:3128",
-		DefaultTemplate:    "map",
+		DefaultTemplate:    DefaultTemplateType,
 		ResourceRequestCPU: DefaultResourceRequestCPU,
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
@@ -512,11 +512,7 @@ func TestSecretMixedTemplatesAnnotations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		pod := testPod(tt.annotations)
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "", "",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -577,11 +573,7 @@ func TestSecretTemplateFileAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "", "",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -14,15 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func basicAgentConfig() AgentConfig {
+	return AgentConfig{
+		Image:              "foobar-image",
+		Address:            "http://foobar:8200",
+		AuthType:           DefaultVaultAuthType,
+		AuthPath:           "test",
+		Namespace:          "test",
+		RevokeOnShutdown:   true,
+		UserID:             "100",
+		GroupID:            "1000",
+		SameID:             DefaultAgentRunAsSameUser,
+		SetSecurityContext: DefaultAgentSetSecurityContext,
+		ProxyAddress:       "http://proxy:3128",
+		DefaultTemplate:    "map",
+		ResourceRequestCPU: DefaultResourceRequestCPU,
+		ResourceRequestMem: DefaultResourceRequestMem,
+		ResourceLimitCPU:   DefaultResourceLimitCPU,
+		ResourceLimitMem:   DefaultResourceLimitMem,
+	}
+}
+
 func TestInitCanSet(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
@@ -56,11 +73,12 @@ func TestInitDefaults(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	agentConfig := AgentConfig{
-		"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "", "",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
+	agentConfig.Image = ""
+	agentConfig.UserID = ""
+	agentConfig.GroupID = ""
+	agentConfig.ProxyAddress = ""
+
 	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
@@ -91,11 +109,9 @@ func TestInitError(t *testing.T) {
 	annotations := make(map[string]string)
 	pod := testPod(annotations)
 
-	agentConfig := AgentConfig{
-		"image", "", DefaultVaultAuthType, "authPath", "namespace", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
+	agentConfig.Address = ""
+
 	err := Init(pod, agentConfig)
 	if err == nil {
 		t.Error("expected error no address, got none")
@@ -156,11 +172,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOff(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -208,11 +220,7 @@ func TestSecretAnnotationsWithPreserveCaseSensitivityFlagOn(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -296,11 +304,7 @@ func TestSecretLocationFileAnnotations(t *testing.T) {
 			pod := testPod(tt.annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			agentConfig := AgentConfig{
-				"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-			}
+			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
@@ -382,11 +386,7 @@ func TestSecretTemplateAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -443,11 +443,7 @@ func TestTemplateShortcuts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			agentConfig := AgentConfig{
-				"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-			}
+			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
@@ -504,11 +500,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		pod := testPod(tt.annotations)
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -637,12 +629,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		annotations := map[string]string{tt.key: tt.value}
 		pod := testPod(annotations)
 		var patches []*jsonpatch.JsonPatchOperation
-
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -659,12 +646,7 @@ func TestCouldErrorAnnotations(t *testing.T) {
 
 func TestInitEmptyPod(t *testing.T) {
 	var pod *corev1.Pod
-
-	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
 	if err == nil {
 		t.Errorf("got no error, should have")
@@ -690,11 +672,7 @@ func TestVaultNamespaceAnnotation(t *testing.T) {
 		pod := testPod(annotation)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -851,11 +829,7 @@ func TestAuthConfigAnnotations(t *testing.T) {
 		pod := testPod(tt.annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-			DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)
@@ -931,11 +905,7 @@ func TestDefaultTemplateOverride(t *testing.T) {
 		pod := testPod(tt.annotations)
 		var patches []*jsonpatch.JsonPatchOperation
 
-		agentConfig := AgentConfig{
-			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-            DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-		}
+		agentConfig := basicAgentConfig()
 		err := Init(pod, agentConfig)
 		if err != nil {
 			t.Errorf("got error, shouldn't have: %s", err)

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -934,6 +934,7 @@ func TestDefaultTemplateOverride(t *testing.T) {
 		agentConfig := AgentConfig{
 			"", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
 			DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
+            DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
 		}
 		err := Init(pod, agentConfig)
 		if err != nil {

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	DefaultTemplate = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
-	TokenTemplate   = "{{ with secret \"auth/token/lookup-self\" }}{{ .Data.id }}\n{{ end }}"
-	TokenSecret     = "auth/token/lookup-self"
-	PidFile         = "/home/vault/.pid"
-	TokenFile       = "/home/vault/.vault-token"
+	DefaultMapTemplate  = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
+	DefaultJSONTemplate = "{{ with secret \"%s\" }}{{ .Data | toJSON }}\n{{ end }}"
+	TokenTemplate       = "{{ with secret \"auth/token/lookup-self\" }}{{ .Data.id }}\n{{ end }}"
+	TokenSecret         = "auth/token/lookup-self"
+	PidFile             = "/home/vault/.pid"
+	TokenFile           = "/home/vault/.vault-token"
 )
 
 // Config is the top level struct that composes a Vault Agent
@@ -103,7 +104,12 @@ func (a *Agent) newTemplateConfigs() []*Template {
 	for _, secret := range a.Secrets {
 		template := secret.Template
 		if template == "" {
-			template = fmt.Sprintf(DefaultTemplate, secret.Path)
+			switch a.DefaultTemplate {
+			case "json":
+				template = fmt.Sprintf(DefaultJSONTemplate, secret.Path)
+			case "map":
+				template = fmt.Sprintf(DefaultMapTemplate, secret.Path)
+			}
 		}
 
 		filePathAndName := fmt.Sprintf("%s/%s", secret.MountPath, secret.Name)

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -10,6 +10,7 @@ import (
 const (
 	DefaultMapTemplate  = "{{ with secret \"%s\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}"
 	DefaultJSONTemplate = "{{ with secret \"%s\" }}{{ .Data | toJSON }}\n{{ end }}"
+	DefaultTemplateType = "map"
 	TokenTemplate       = "{{ with secret \"auth/token/lookup-self\" }}{{ .Data.id }}\n{{ end }}"
 	TokenSecret         = "auth/token/lookup-self"
 	PidFile             = "/home/vault/.pid"
@@ -104,18 +105,16 @@ func (a *Agent) newTemplateConfigs() []*Template {
 	var templates []*Template
 	for _, secret := range a.Secrets {
 		template := secret.Template
-		if template == "" {
-			switch a.DefaultTemplate {
-			case "json":
-				template = fmt.Sprintf(DefaultJSONTemplate, secret.Path)
-			case "map":
-				template = fmt.Sprintf(DefaultMapTemplate, secret.Path)
-
 		templateFile := secret.TemplateFile
 		if templateFile == "" {
 			template = secret.Template
 			if template == "" {
-				template = fmt.Sprintf(DefaultTemplate, secret.Path)
+				switch a.DefaultTemplate {
+				case "json":
+					template = fmt.Sprintf(DefaultJSONTemplate, secret.Path)
+				case "map":
+					template = fmt.Sprintf(DefaultMapTemplate, secret.Path)
+				}
 			}
 		}
 

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -45,7 +45,7 @@ func TestNewConfig(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestFilePathAndName(t *testing.T) {
 
 			agentConfig := AgentConfig{
 				"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 			}
 			err := Init(pod, agentConfig)
 			if err != nil {
@@ -243,7 +243,7 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -282,7 +282,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 
 	agentConfig := AgentConfig{
 		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 	}
 	err := Init(pod, agentConfig)
 	if err != nil {
@@ -414,7 +414,7 @@ func TestConfigVaultAgentCache_persistent(t *testing.T) {
 
 			agentConfig := AgentConfig{
 				"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "",
+				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
 			}
 			err := Init(pod, agentConfig)
 			require.NoError(t, err, "got error initialising pod: %s", err)

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -47,11 +47,7 @@ func TestNewConfig(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
@@ -221,11 +217,7 @@ func TestFilePathAndName(t *testing.T) {
 			pod := testPod(tt.annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			agentConfig := AgentConfig{
-				"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-			}
+			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			if err != nil {
 				t.Errorf("got error initialising pod, shouldn't have: %s", err)
@@ -254,11 +246,7 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
@@ -294,11 +282,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-	}
+	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
@@ -427,11 +411,7 @@ func TestConfigVaultAgentCache_persistent(t *testing.T) {
 			pod := testPod(tt.annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			agentConfig := AgentConfig{
-				"foobar-image", "http://foobar:8200", DefaultVaultAuthType, "test", "test", true, "100", "1000",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
-			}
+			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			require.NoError(t, err, "got error initialising pod: %s", err)
 

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -40,8 +40,11 @@ func TestContainerSidecarVolume(t *testing.T) {
 
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
+	agentConfig := AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType,
+		"test", "test", true, "1000", "100", DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext, "", "map"}
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -102,7 +105,11 @@ func TestContainerSidecar(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", false, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "http://proxy:3128"})
+	agentConfig := AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType,
+		"test", "test", false, "1000", "100", DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext, "http://proxy:3128", "map"}
+
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -215,7 +222,11 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			pod := testPod(annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", tt.revokeFlag, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
+			agentConfig := AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType,
+				"test", "test", tt.revokeFlag, "1000", "100", DefaultAgentRunAsSameUser,
+				DefaultAgentSetSecurityContext, "", "map"}
+
+			err := Init(pod, agentConfig)
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -264,7 +275,11 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
+	agentConfig := AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType,
+		"test", "test", true, "1000", "100", DefaultAgentRunAsSameUser,
+		DefaultAgentSetSecurityContext, "", "map"}
+
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -960,7 +975,11 @@ func TestContainerCache(t *testing.T) {
 			pod := testPod(tt.annotations)
 			var patches []*jsonpatch.JsonPatchOperation
 
-			err := Init(pod, AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100", DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, ""})
+			agentConfig := AgentConfig{"foobar-image", "http://foobar:1234", DefaultVaultAuthType,
+				"test", "test", true, "1000", "100", DefaultAgentRunAsSameUser,
+				DefaultAgentSetSecurityContext, "", "map"}
+
+			err := Init(pod, agentConfig)
 			require.NoError(t, err)
 
 			agent, err := New(pod, patches)

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -113,7 +113,7 @@ func TestContainerSidecar(t *testing.T) {
 		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
 	}
 
-  err := Init(pod, agentConfig)
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -232,7 +232,7 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
 			}
 
-      err := Init(pod, agentConfig)
+			err := Init(pod, agentConfig)
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
@@ -287,7 +287,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
 	}
 
-  err := Init(pod, agentConfig)
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -48,6 +48,7 @@ type Handler struct {
 	GroupID            string
 	SameID             bool
 	SetSecurityContext bool
+	DefaultTemplate    string
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -154,6 +155,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		GroupID:            h.GroupID,
 		SameID:             h.SameID,
 		SetSecurityContext: h.SetSecurityContext,
+		DefaultTemplate:    h.DefaultTemplate,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -16,6 +16,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+func basicHandler() Handler {
+	return Handler{
+		VaultAddress:    "https://vault:8200",
+		VaultAuthPath:   "kubernetes",
+		ImageVault:      "vault",
+		Log:             hclog.Default().Named("handler"),
+		DefaultTemplate: "map",
+	}
+}
+
 func TestHandlerHandle(t *testing.T) {
 	basicSpec := corev1.PodSpec{
 		InitContainers: []corev1.Container{
@@ -57,7 +67,7 @@ func TestHandlerHandle(t *testing.T) {
 	}{
 		{
 			"kube-system namespace",
-			Handler{Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: metav1.NamespaceSystem,
 				Object: encodeRaw(t, &corev1.Pod{
@@ -76,7 +86,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"already injected",
-			Handler{Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +104,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"no injection by default",
-			Handler{Log: hclog.Default().Named("handler")},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					Spec: basicSpec,
@@ -106,7 +116,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"injection disabled",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -125,7 +135,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"basic pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), ProxyAddress: "http://proxy:3128", DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -177,7 +187,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"init first ",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -238,7 +248,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -294,7 +304,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -355,7 +365,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -412,7 +422,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap no init pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -458,7 +468,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap init only pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -508,7 +518,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"copy volume mounts pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -560,7 +570,7 @@ func TestHandlerHandle(t *testing.T) {
 		},
 		{
 			"invalid default template",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			basicHandler(),
 			v1beta1.AdmissionRequest{
 				Namespace: "foo",
 				Object: encodeRaw(t, &corev1.Pod{

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -22,7 +22,7 @@ func basicHandler() Handler {
 		VaultAuthPath:   "kubernetes",
 		ImageVault:      "vault",
 		Log:             hclog.Default().Named("handler"),
-		DefaultTemplate: "map",
+		DefaultTemplate: agent.DefaultTemplateType,
 	}
 }
 

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -57,7 +57,7 @@ func TestHandlerHandle(t *testing.T) {
 	}{
 		{
 			"kube-system namespace",
-			Handler{Log: hclog.Default().Named("handler")},
+			Handler{Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: metav1.NamespaceSystem,
 				Object: encodeRaw(t, &corev1.Pod{
@@ -76,7 +76,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"already injected",
-			Handler{Log: hclog.Default().Named("handler")},
+			Handler{Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +106,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"injection disabled",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -125,7 +125,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"basic pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), ProxyAddress: "http://proxy:3128"},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), ProxyAddress: "http://proxy:3128", DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -177,7 +177,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"init first ",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -238,7 +238,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -294,7 +294,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -355,7 +355,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -412,7 +412,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap no init pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -458,7 +458,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"tls no configmap init only pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -508,7 +508,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"copy volume mounts pod injection",
-			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler")},
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
 			v1beta1.AdmissionRequest{
 				Namespace: "test",
 				Object: encodeRaw(t, &corev1.Pod{
@@ -557,6 +557,25 @@ func TestHandlerHandle(t *testing.T) {
 					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
 				},
 			},
+		},
+		{
+			"invalid default template",
+			Handler{VaultAddress: "https://vault:8200", VaultAuthPath: "kubernetes", ImageVault: "vault", Log: hclog.Default().Named("handler"), DefaultTemplate: "map"},
+			v1beta1.AdmissionRequest{
+				Namespace: "foo",
+				Object: encodeRaw(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							agent.AnnotationAgentInject:                "true",
+							agent.AnnotationVaultRole:                  "demo",
+							agent.AnnotationAgentInjectDefaultTemplate: "foobar",
+						},
+					},
+					Spec: basicSpec,
+				}),
+			},
+			"invalid default template type",
+			nil,
 		},
 	}
 

--- a/deploy/injector-deployment.yaml
+++ b/deploy/injector-deployment.yaml
@@ -76,6 +76,8 @@ spec:
               value: "vault-agent-injector-svc,vault-agent-injector-svc.$(NAMESPACE),vault-agent-injector-svc.$(NAMESPACE).svc"
             - name: AGENT_INJECT_USE_LEADER_ELECTOR
               value: "true"
+            - name: AGENT_INJECT_DEFAULT_TEMPLATE
+              value: "map"
           args:
             - agent-inject
             - 2>&1

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -51,6 +51,7 @@ type Command struct {
 	flagSetSecurityContext bool   // Set SecurityContext in injected containers
 	flagTelemetryPath      string // Path under which to expose metrics
 	flagUseLeaderElector   bool   // Use leader elector code
+	flagDefaultTemplate    string // Toggles which default template to use
 
 	flagSet *flag.FlagSet
 
@@ -76,6 +77,14 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagVaultService == "" {
 		c.UI.Error("No Vault service configured")
+		return 1
+	}
+
+	switch c.flagDefaultTemplate {
+	case "map":
+	case "json":
+	default:
+		c.UI.Error(fmt.Sprintf("Invalid default flag type: %s", c.flagDefaultTemplate))
 		return 1
 	}
 
@@ -157,6 +166,7 @@ func (c *Command) Run(args []string) int {
 		GroupID:            c.flagRunAsGroup,
 		SameID:             c.flagRunAsSameUser,
 		SetSecurityContext: c.flagSetSecurityContext,
+		DefaultTemplate:    c.flagDefaultTemplate,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -77,6 +77,9 @@ type Specification struct {
 
 	// UseLeaderElector is the AGENT_INJECT_USE_LEADER_ELECTOR environment variable.
 	UseLeaderElector string `split_words:"true"`
+
+	// DefaultTemplate is the AGENT_INJECT_DEFAULT_TEMPLATE environment variable.
+	DefaultTemplate string `split_words:"true"`
 }
 
 func (c *Command) init() {
@@ -120,6 +123,8 @@ func (c *Command) init() {
 		"Path under which to expose metrics")
 	c.flagSet.BoolVar(&c.flagUseLeaderElector, "use-leader-elector", agent.DefaultAgentUseLeaderElector,
 		fmt.Sprintf("Use leader elector to coordinate multiple replicas when updating CA and Certs with auto-tls"))
+	c.flagSet.StringVar(&c.flagDefaultTemplate, "default-template", "map",
+		"Sets the default template type (map or json). Defaults to map.")
 
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -239,6 +244,10 @@ func (c *Command) parseEnvs() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if envs.DefaultTemplate != "" {
+		c.flagDefaultTemplate = envs.DefaultTemplate
 	}
 
 	return nil

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -134,8 +134,8 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagTelemetryPath, "telemetry-path", "",
 		"Path under which to expose metrics")
 	c.flagSet.BoolVar(&c.flagUseLeaderElector, "use-leader-elector", agent.DefaultAgentUseLeaderElector,
-		fmt.Sprintf("Use leader elector to coordinate multiple replicas when updating CA and Certs with auto-tls"))
-	c.flagSet.StringVar(&c.flagDefaultTemplate, "default-template", "map",
+		"Use leader elector to coordinate multiple replicas when updating CA and Certs with auto-tls")
+	c.flagSet.StringVar(&c.flagDefaultTemplate, "default-template", agent.DefaultTemplateType,
 		"Sets the default template type (map or json). Defaults to map.")
 
 	c.flagSet.StringVar(&c.flagResourceRequestCPU, "cpu-request", agent.DefaultResourceRequestCPU,
@@ -270,7 +270,7 @@ func (c *Command) parseEnvs() error {
 
 	if envs.DefaultTemplate != "" {
 		c.flagDefaultTemplate = envs.DefaultTemplate
-  }
+	}
 
 	if envs.ResourceRequestCPU != "" {
 		c.flagResourceRequestCPU = envs.ResourceRequestCPU

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -125,6 +125,7 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_RUN_AS_USER", value: "1000", cmdPtr: &cmd.flagRunAsUser},
 		{env: "AGENT_INJECT_RUN_AS_GROUP", value: "1001", cmdPtr: &cmd.flagRunAsGroup},
 		{env: "AGENT_INJECT_TELEMETRY_PATH", value: "/metrics", cmdPtr: &cmd.flagTelemetryPath},
+		{env: "AGENT_INJECT_DEFAULT_TEMPLATE", value: "json", cmdPtr: &cmd.flagDefaultTemplate},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The current default template (a map) is not easy to consume by applications due to the weird formatting. I've added a global default via flag/env (`AGENT_INJECT_DEFAULT_TEMPLATE`), as well as an annotation (`agent-inject-default-template`) to override this to either be `map` or `json`. I'm keeping the default as `map` so this is backwards compatible in case any application is actually using that style of value.

Once merged we can expose the global in Vault Helm.

Fixes #116.