### PR TITLE
Add annotation support for multiple ConfigMap templates

### DIFF
--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -110,6 +110,25 @@ func TestValidate(t *testing.T) {
 				ServiceAccountPath: "foobar",
 				ServiceAccountName: "foobar",
 				ImageName:          "test",
+				ConfigMapName:      "test",
+				ConfigMapNames:     "test1,test2,test3",
+			}, false,
+		},
+		{
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				ImageName:          "test",
+				ConfigMapNames:     "test1,test2,test3",
+			}, true,
+		},
+		{
+			Agent{
+				Namespace:          "test",
+				ServiceAccountPath: "foobar",
+				ServiceAccountName: "foobar",
+				ImageName:          "test",
 				Vault: Vault{
 					Role:     "test",
 					Address:  "https://foobar.com:8200",

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -94,6 +94,10 @@ const (
 	// configuration file and templates can be found.
 	AnnotationAgentConfigMap = "vault.hashicorp.com/agent-configmap"
 
+	// AnnotationAgentConfigMap is a comma-separated list of the configuration mappings where Vault Agent
+	// configuration files and templatess can be found.
+	AnnotationAgentConfigMaps = "vault.hashicorp.com/agent-configmaps"
+
 	// AnnotationAgentExtraSecret is the name of a Kubernetes secret that will be mounted
 	// into the Vault agent container so that the agent config can reference secrets.
 	AnnotationAgentExtraSecret = "vault.hashicorp.com/agent-extra-secret"

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -45,7 +46,7 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 		})
 	}
 
-	if a.ConfigMapName == "" {
+	if a.ConfigMapName == "" && a.ConfigMapNames == "" {
 		config, err := a.newConfig(init)
 		if err != nil {
 			return envs, err

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -16,10 +16,12 @@ func TestContainerEnvs(t *testing.T) {
 	}{
 		{Agent{}, []string{"VAULT_CONFIG"}},
 		{Agent{ConfigMapName: "foobar"}, []string{}},
+		{Agent{ConfigMapNames: "foobar"}, []string{}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
 		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
+		{Agent{ConfigMapNames: "barbaz", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
 	}
 
 	for _, tt := range tests {
@@ -45,7 +47,7 @@ func TestContainerEnvsForIRSA(t *testing.T) {
 		expectedEnvs []string
 	}{
 		{Agent{Pod: testPodWithoutIRSA()}, []string{"VAULT_CONFIG"}},
-		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws",}}, 
+		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
 			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
 		},
 	}

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -47,7 +47,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 
 	arg := DefaultContainerArg
 
-	if a.ConfigMapName != "" {
+	if a.ConfigMapName != "" || a.ConfigMapNames != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      configVolumeName,
 			MountPath: configVolumePath,

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -59,7 +59,7 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 
 	arg := DefaultContainerArg
 
-	if a.ConfigMapName != "" {
+	if a.ConfigMapName != "" || a.ConfigMapNames != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      configVolumeName,
 			MountPath: configVolumePath,

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	corev1 "k8s.io/api/core/v1"
@@ -106,6 +107,27 @@ func (a *Agent) ContainerConfigMapVolume() corev1.Volume {
 			},
 		},
 	}
+}
+
+// ContainerConfigMapVolume returns a list of volumes to mount
+// a comma-separated list of config maps if the user supplied any.
+func (a *Agent) ContainerConfigMapVolumes() []corev1.Volume {
+	var configMapNames = strings.Split(a.ConfigMapNames, ",")
+	var volumes []corev1.Volume
+	for _, configMapName := range configMapNames {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: configVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+					},
+				},
+			})
+	}
+	return volumes
 }
 
 // ContainerExtraSecretVolume returns a volume to mount a Kube secret


### PR DESCRIPTION
If applied, this pull request will create a new annotation, `"vault.hashicorp.com/agent-configmaps"`, that will parse and patch configurations with multiple comma-separated ConfigMaps to be mounted.

First-time contributor, and I'm not a gopher by any means. Please let me know what I can do to make this merge-ready.

Resolves #102 
