### PR TITLE
Pass the hclog logger into notify and http.Server

### DIFF
--- a/helper/cert/notify.go
+++ b/helper/cert/notify.go
@@ -54,7 +54,7 @@ func (n *Notify) Run() {
 
 		next, err := n.source.Certificate(n.ctx, last)
 		if err != nil {
-			n.logger.Warn("error loading next cert", "err", err.Error())
+			n.logger.Warn("error loading next cert", "error", err.Error())
 			continue
 		}
 

--- a/helper/cert/notify.go
+++ b/helper/cert/notify.go
@@ -2,22 +2,25 @@ package cert
 
 import (
 	"context"
-	"log"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
 )
 
-func NewNotify(ctx context.Context, newBundle chan<- Bundle, source Source) *Notify {
+func NewNotify(ctx context.Context, newBundle chan<- Bundle, source Source, logger hclog.Logger) *Notify {
 	return &Notify{
 		ctx:    ctx,
 		ch:     newBundle,
 		source: source,
+		logger: logger,
 	}
 }
 
 // Notify sends an update on a channel whenever a source has an updated
 // cert bundle. This struct maintains state, performs backoffs, etc.
 type Notify struct {
-	ctx context.Context
+	ctx    context.Context
+	logger hclog.Logger
 
 	// ch is where the notifications for new bundles are sent. If this
 	// blocks then the notify loop will also be blocked, so downstream
@@ -51,7 +54,7 @@ func (n *Notify) Run() {
 
 		next, err := n.source.Certificate(n.ctx, last)
 		if err != nil {
-			log.Printf("[ERROR] helper/cert: error loading next cert: %s", err)
+			n.logger.Warn("error loading next cert", "err", err.Error())
 			continue
 		}
 

--- a/helper/cert/notify_test.go
+++ b/helper/cert/notify_test.go
@@ -19,7 +19,7 @@ func TestNotify(t *testing.T) {
 
 	// Create notifier
 	ch := make(chan Bundle)
-	n := NewNotify(context.Background(), ch, source)
+	n := NewNotify(context.Background(), ch, source, hclog.NewNullLogger())
 	go n.Run()
 
 	// We should receive an update almost immediately
@@ -68,7 +68,7 @@ func TestNotifyRace(t *testing.T) {
 			Hosts: []string{"some", "hosts"},
 			Log:   hclog.Default(),
 		}
-		n := NewNotify(ctx, certCh, certSource)
+		n := NewNotify(ctx, certCh, certSource, hclog.NewNullLogger())
 
 		go func() {
 			<-start

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -151,7 +151,7 @@ func (c *Command) Run(args []string) int {
 	// Create the certificate notifier so we can update for certificates,
 	// then start all the background routines for updating certificates.
 	certCh := make(chan cert.Bundle)
-	certNotify := cert.NewNotify(ctx, certCh, certSource)
+	certNotify := cert.NewNotify(ctx, certCh, certSource, logger.Named("notify"))
 	go certNotify.Run()
 	go c.certWatcher(ctx, certCh, clientset, logger.Named("certwatcher"))
 
@@ -192,6 +192,7 @@ func (c *Command) Run(args []string) int {
 		Addr:      c.flagListen,
 		Handler:   handler,
 		TLSConfig: &tls.Config{GetCertificate: c.getCertificate},
+		ErrorLog:  logger.StandardLogger(&hclog.StandardLoggerOptions{ForceLevel: hclog.Error}),
 	}
 
 	trap := make(chan os.Signal, 1)


### PR DESCRIPTION
This ensures that the log message from notify.Run() and http server errors are logged in the same format as the rest of the injector.

For instance, the log format should be like this:

```
2021-04-23T23:16:27.507Z [INFO]  handler.certwatcher: Updated certificate bundle received. Updating certs... `
```

But currently notify and the http server log like this:
```
2021/04/23 23:16:32 http: TLS handshake error from 10.244.0.1:45764: no certificate available
2021/04/23 23:17:17 [ERROR] helper/cert: error loading next cert: failed to get secret: secret "vault-injector-certs" not found
```

with this PR:
```
2021-04-23T23:36:33.609Z [ERROR] handler: http: TLS handshake error from 10.244.0.1:60360: no certificate available
2021-04-23T23:36:28.732Z [WARN]  handler.notify: error loading next cert: err="Get "http://localhost:4040/": dial tcp [::1]:4040: connect: connection refused"
```