### PR TITLE
Update dev image to 0.10.1

### DIFF
--- a/build/docker/Dev.dockerfile
+++ b/build/docker/Dev.dockerfile
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/alpine:latest
 
-ARG VERSION=0.10.0
+ARG VERSION=0.10.1
 
 RUN addgroup vault && \
     adduser -S -G vault vault


### PR DESCRIPTION
Minor release to fix some bugs and address the CVE reported in #254. I verified after building the new image this package is updated:

```bash
/ # apk info -vv | grep apk-tools
apk-tools-2.12.5-r0 - Alpine Package Keeper - package manager for alpine
```

CI will update other versions and the Vault Agent default version.