### PR TITLE
Add a name to the service port

### DIFF
--- a/deploy/injector-service.yaml
+++ b/deploy/injector-service.yaml
@@ -8,7 +8,8 @@ metadata:
     app.kubernetes.io/instance: vault
 spec:
   ports:
-  - port: 443
+  - name: https
+    port: 443
     targetPort: 8080
   selector:
     app.kubernetes.io/name: vault-injector


### PR DESCRIPTION
The prometheus operator requires a named service port. This also matches the service created by the vault [helm chart](https://github.com/hashicorp/vault-helm/blob/3afcb463f8672e55c5632312228a02422eeb7cc9/templates/injector-service.yaml#L14).