### PR TITLE
agent-inject: add exit_on_retry_failure flag and annotation

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -14,23 +14,23 @@ import (
 // TODO swap out 'github.com/mattbaird/jsonpatch' for 'github.com/evanphx/json-patch'
 
 const (
-	DefaultVaultImage                            = "vault:1.7.3"
-	DefaultVaultAuthType                         = "kubernetes"
-	DefaultVaultAuthPath                         = "auth/kubernetes"
-	DefaultAgentRunAsUser                        = 100
-	DefaultAgentRunAsGroup                       = 1000
-	DefaultAgentRunAsSameUser                    = false
-	DefaultAgentAllowPrivilegeEscalation         = false
-	DefaultAgentDropCapabilities                 = "ALL"
-	DefaultAgentSetSecurityContext               = true
-	DefaultAgentReadOnlyRoot                     = true
-	DefaultAgentCacheEnable                      = "false"
-	DefaultAgentCacheUseAutoAuthToken            = "true"
-	DefaultAgentCacheListenerPort                = "8200"
-	DefaultAgentCacheExitOnErr                   = false
-	DefaultAgentUseLeaderElector                 = false
-	DefaultAgentInjectToken                      = false
-	DefaultAgentTemplateConfigExitOnRetryFailure = true
+	DefaultVaultImage                       = "vault:1.7.3"
+	DefaultVaultAuthType                    = "kubernetes"
+	DefaultVaultAuthPath                    = "auth/kubernetes"
+	DefaultAgentRunAsUser                   = 100
+	DefaultAgentRunAsGroup                  = 1000
+	DefaultAgentRunAsSameUser               = false
+	DefaultAgentAllowPrivilegeEscalation    = false
+	DefaultAgentDropCapabilities            = "ALL"
+	DefaultAgentSetSecurityContext          = true
+	DefaultAgentReadOnlyRoot                = true
+	DefaultAgentCacheEnable                 = "false"
+	DefaultAgentCacheUseAutoAuthToken       = "true"
+	DefaultAgentCacheListenerPort           = "8200"
+	DefaultAgentCacheExitOnErr              = false
+	DefaultAgentUseLeaderElector            = false
+	DefaultAgentInjectToken                 = false
+	DefaultTemplateConfigExitOnRetryFailure = true
 )
 
 // Agent is the top level structure holding all the
@@ -267,7 +267,7 @@ type VaultAgentCache struct {
 }
 
 type VaultAgentTemplateConfig struct {
-	// ExitOnRetryFailure configure whether agent should exit after failing
+	// ExitOnRetryFailure configures whether agent should exit after failing
 	// all its retry attempts when rendering templates
 	ExitOnRetryFailure bool
 }

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -227,10 +227,10 @@ const (
 	// sidecar containers. Ignores any Kubernetes service account token mounts.
 	AnnotationAgentCopyVolumeMounts = "vault.hashicorp.com/agent-copy-volume-mounts"
 
-	// AnnotationAgentTemplateConfigExitOnRetryFailure configure whether agent
+	// AnnotationTemplateConfigExitOnRetryFailure configures whether agent
 	// will exit on template render failures once it has exhausted all its retry
 	// attempts. Defaults to true.
-	AnnotationAgentTemplateConfigExitOnRetryFailure = "vault.hashicorp.com/agent-template-config-exit-on-retry-failure"
+	AnnotationTemplateConfigExitOnRetryFailure = "vault.hashicorp.com/template-config-exit-on-retry-failure"
 )
 
 type AgentConfig struct {
@@ -399,8 +399,8 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 		pod.ObjectMeta.Annotations[AnnotationAgentInjectDefaultTemplate] = cfg.DefaultTemplate
 	}
 
-	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentTemplateConfigExitOnRetryFailure]; !ok {
-		pod.ObjectMeta.Annotations[AnnotationAgentTemplateConfigExitOnRetryFailure] = strconv.FormatBool(cfg.ExitOnRetryFailure)
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigExitOnRetryFailure]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationTemplateConfigExitOnRetryFailure] = strconv.FormatBool(cfg.ExitOnRetryFailure)
 	}
 
 	return nil
@@ -592,9 +592,9 @@ func (a *Agent) cacheEnable() (bool, error) {
 }
 
 func (a *Agent) templateConfigExitOnRetryFailure() (bool, error) {
-	raw, ok := a.Annotations[AnnotationAgentTemplateConfigExitOnRetryFailure]
+	raw, ok := a.Annotations[AnnotationTemplateConfigExitOnRetryFailure]
 	if !ok {
-		return DefaultAgentTemplateConfigExitOnRetryFailure, nil
+		return DefaultTemplateConfigExitOnRetryFailure, nil
 	}
 
 	return strconv.ParseBool(raw)

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -32,7 +32,7 @@ func basicAgentConfig() AgentConfig {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
-		ExitOnRetryFailure: true,
+		ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 	}
 }
 

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -32,6 +32,7 @@ func basicAgentConfig() AgentConfig {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
+		ExitOnRetryFailure: true,
 	}
 }
 

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -19,13 +19,14 @@ const (
 // Config is the top level struct that composes a Vault Agent
 // configuration file.
 type Config struct {
-	AutoAuth      *AutoAuth    `json:"auto_auth"`
-	ExitAfterAuth bool         `json:"exit_after_auth"`
-	PidFile       string       `json:"pid_file"`
-	Vault         *VaultConfig `json:"vault"`
-	Templates     []*Template  `json:"template,omitempty"`
-	Listener      []*Listener  `json:"listener,omitempty"`
-	Cache         *Cache       `json:"cache,omitempty"`
+	AutoAuth       *AutoAuth       `json:"auto_auth"`
+	ExitAfterAuth  bool            `json:"exit_after_auth"`
+	PidFile        string          `json:"pid_file"`
+	Vault          *VaultConfig    `json:"vault"`
+	Templates      []*Template     `json:"template,omitempty"`
+	Listener       []*Listener     `json:"listener,omitempty"`
+	Cache          *Cache          `json:"cache,omitempty"`
+	TemplateConfig *TemplateConfig `json:"template_config,omitempty"`
 }
 
 // Vault contains configuration for connecting to Vault servers
@@ -100,6 +101,11 @@ type CachePersist struct {
 	ServiceAccountTokenFile string `json:"service_account_token_file,omitempty"`
 }
 
+// TemplateConfig defines the configuration for template_config in Vault Agent
+type TemplateConfig struct {
+	ExitOnRetryFailure bool `json:"exit_on_retry_failure"`
+}
+
 func (a *Agent) newTemplateConfigs() []*Template {
 	var templates []*Template
 	for _, secret := range a.Secrets {
@@ -165,6 +171,9 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 			},
 		},
 		Templates: a.newTemplateConfigs(),
+		TemplateConfig: &TemplateConfig{
+			ExitOnRetryFailure: a.VaultAgentTemplateConfig.ExitOnRetryFailure,
+		},
 	}
 
 	if a.InjectToken {

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -41,9 +41,22 @@ func TestContainerSidecarVolume(t *testing.T) {
 	pod := testPod(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
+		Image:              "foobar-image",
+		Address:            "http://foobar:1234",
+		AuthType:           DefaultVaultAuthType,
+		AuthPath:           "test",
+		Namespace:          "test",
+		RevokeOnShutdown:   true,
+		UserID:             "1000",
+		GroupID:            "100",
+		SameID:             DefaultAgentRunAsSameUser,
+		SetSecurityContext: DefaultAgentSetSecurityContext,
+		DefaultTemplate:    "map",
+		ResourceRequestCPU: DefaultResourceRequestCPU,
+		ResourceRequestMem: DefaultResourceRequestMem,
+		ResourceLimitCPU:   DefaultResourceLimitCPU,
+		ResourceLimitMem:   DefaultResourceLimitMem,
+		ExitOnRetryFailure: true,
 	}
 
 	err := Init(pod, agentConfig)
@@ -122,10 +135,26 @@ func TestContainerSidecarVolumeWithIRSA(t *testing.T) {
 	pod := testPodIRSA(annotations)
 	var patches []*jsonpatch.JsonPatchOperation
 
-	err := Init(pod, AgentConfig{
-		"foobar-image", "http://foobar:1234", "aws", "test", "test", true, "1000", "100",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem})
+	agentConfig := AgentConfig{
+		Image:              "foobar-image",
+		Address:            "http://foobar:1234",
+		AuthType:           "aws",
+		AuthPath:           "test",
+		Namespace:          "test",
+		RevokeOnShutdown:   true,
+		UserID:             "1000",
+		GroupID:            "100",
+		SameID:             DefaultAgentRunAsSameUser,
+		SetSecurityContext: DefaultAgentSetSecurityContext,
+		DefaultTemplate:    "map",
+		ResourceRequestCPU: DefaultResourceRequestCPU,
+		ResourceRequestMem: DefaultResourceRequestMem,
+		ResourceLimitCPU:   DefaultResourceLimitCPU,
+		ResourceLimitMem:   DefaultResourceLimitMem,
+		ExitOnRetryFailure: true,
+	}
+
+	err := Init(pod, agentConfig)
 	if err != nil {
 		t.Errorf("got error, shouldn't have: %s", err)
 	}
@@ -184,9 +213,22 @@ func TestContainerSidecar(t *testing.T) {
 	var patches []*jsonpatch.JsonPatchOperation
 
 	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", false, "1000", "100",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "https://proxy:3128", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
+		Image:              "foobar-image",
+		Address:            "http://foobar:1234",
+		AuthType:           DefaultVaultAuthType,
+		AuthPath:           "test",
+		Namespace:          "test",
+		UserID:             "1000",
+		GroupID:            "100",
+		SameID:             DefaultAgentRunAsSameUser,
+		SetSecurityContext: DefaultAgentSetSecurityContext,
+		ProxyAddress:       "https://proxy:3128",
+		DefaultTemplate:    "map",
+		ResourceRequestCPU: DefaultResourceRequestCPU,
+		ResourceRequestMem: DefaultResourceRequestMem,
+		ResourceLimitCPU:   DefaultResourceLimitCPU,
+		ResourceLimitMem:   DefaultResourceLimitMem,
+		ExitOnRetryFailure: true,
 	}
 
 	err := Init(pod, agentConfig)
@@ -303,9 +345,22 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := AgentConfig{
-				"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", tt.revokeFlag, "1000", "100",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
+				Image:              "foobar-image",
+				Address:            "http://foobar:1234",
+				AuthType:           DefaultVaultAuthType,
+				AuthPath:           "test",
+				Namespace:          "test",
+				RevokeOnShutdown:   tt.revokeFlag,
+				UserID:             "1000",
+				GroupID:            "100",
+				SameID:             DefaultAgentRunAsSameUser,
+				SetSecurityContext: DefaultAgentSetSecurityContext,
+				DefaultTemplate:    "map",
+				ResourceRequestCPU: DefaultResourceRequestCPU,
+				ResourceRequestMem: DefaultResourceRequestMem,
+				ResourceLimitCPU:   DefaultResourceLimitCPU,
+				ResourceLimitMem:   DefaultResourceLimitMem,
+				ExitOnRetryFailure: true,
 			}
 
 			err := Init(pod, agentConfig)
@@ -358,9 +413,22 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	var patches []*jsonpatch.JsonPatchOperation
 
 	agentConfig := AgentConfig{
-		"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100",
-		DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-		DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
+		Image:              "foobar-image",
+		Address:            "http://foobar:1234",
+		AuthType:           DefaultVaultAuthType,
+		AuthPath:           "test",
+		Namespace:          "test",
+		RevokeOnShutdown:   true,
+		UserID:             "1000",
+		GroupID:            "100",
+		SameID:             DefaultAgentRunAsSameUser,
+		SetSecurityContext: DefaultAgentSetSecurityContext,
+		DefaultTemplate:    "map",
+		ResourceRequestCPU: DefaultResourceRequestCPU,
+		ResourceRequestMem: DefaultResourceRequestMem,
+		ResourceLimitCPU:   DefaultResourceLimitCPU,
+		ResourceLimitMem:   DefaultResourceLimitMem,
+		ExitOnRetryFailure: true,
 	}
 
 	err := Init(pod, agentConfig)
@@ -1060,9 +1128,22 @@ func TestContainerCache(t *testing.T) {
 			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := AgentConfig{
-				"foobar-image", "http://foobar:1234", DefaultVaultAuthType, "test", "test", true, "1000", "100",
-				DefaultAgentRunAsSameUser, DefaultAgentSetSecurityContext, "", "map",
-				DefaultResourceRequestCPU, DefaultResourceRequestMem, DefaultResourceLimitCPU, DefaultResourceLimitMem,
+				Image:              "foobar-image",
+				Address:            "http://foobar:1234",
+				AuthType:           DefaultVaultAuthType,
+				AuthPath:           "test",
+				Namespace:          "test",
+				RevokeOnShutdown:   true,
+				UserID:             "1000",
+				GroupID:            "100",
+				SameID:             DefaultAgentRunAsSameUser,
+				SetSecurityContext: DefaultAgentSetSecurityContext,
+				DefaultTemplate:    "map",
+				ResourceRequestCPU: DefaultResourceRequestCPU,
+				ResourceRequestMem: DefaultResourceRequestMem,
+				ResourceLimitCPU:   DefaultResourceLimitCPU,
+				ResourceLimitMem:   DefaultResourceLimitMem,
+				ExitOnRetryFailure: true,
 			}
 
 			err := Init(pod, agentConfig)

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -56,7 +56,7 @@ func TestContainerSidecarVolume(t *testing.T) {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
-		ExitOnRetryFailure: true,
+		ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 	}
 
 	err := Init(pod, agentConfig)
@@ -151,7 +151,7 @@ func TestContainerSidecarVolumeWithIRSA(t *testing.T) {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
-		ExitOnRetryFailure: true,
+		ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 	}
 
 	err := Init(pod, agentConfig)
@@ -228,7 +228,7 @@ func TestContainerSidecar(t *testing.T) {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
-		ExitOnRetryFailure: true,
+		ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 	}
 
 	err := Init(pod, agentConfig)
@@ -360,7 +360,7 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 				ResourceRequestMem: DefaultResourceRequestMem,
 				ResourceLimitCPU:   DefaultResourceLimitCPU,
 				ResourceLimitMem:   DefaultResourceLimitMem,
-				ExitOnRetryFailure: true,
+				ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 			}
 
 			err := Init(pod, agentConfig)
@@ -428,7 +428,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		ResourceRequestMem: DefaultResourceRequestMem,
 		ResourceLimitCPU:   DefaultResourceLimitCPU,
 		ResourceLimitMem:   DefaultResourceLimitMem,
-		ExitOnRetryFailure: true,
+		ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 	}
 
 	err := Init(pod, agentConfig)
@@ -1143,7 +1143,7 @@ func TestContainerCache(t *testing.T) {
 				ResourceRequestMem: DefaultResourceRequestMem,
 				ResourceLimitCPU:   DefaultResourceLimitCPU,
 				ResourceLimitMem:   DefaultResourceLimitMem,
-				ExitOnRetryFailure: true,
+				ExitOnRetryFailure: DefaultTemplateConfigExitOnRetryFailure,
 			}
 
 			err := Init(pod, agentConfig)

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -53,6 +53,7 @@ type Handler struct {
 	ResourceRequestMem string
 	ResourceLimitCPU   string
 	ResourceLimitMem   string
+	ExitOnRetryFailure bool
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -164,6 +165,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		ResourceRequestMem: h.ResourceRequestMem,
 		ResourceLimitCPU:   h.ResourceLimitCPU,
 		ResourceLimitMem:   h.ResourceLimitMem,
+		ExitOnRetryFailure: h.ExitOnRetryFailure,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -37,6 +37,7 @@ type Command struct {
 	flagLogFormat          string // Log format
 	flagCertFile           string // TLS Certificate to serve
 	flagKeyFile            string // TLS private key to serve
+	flagExitOnRetryFailure bool   // Set template_config.exit_on_retry_failure on agent
 	flagAutoName           string // MutatingWebhookConfiguration for updating
 	flagAutoHosts          string // SANs for the auto-generated TLS cert.
 	flagVaultService       string // Name of the Vault service
@@ -175,6 +176,7 @@ func (c *Command) Run(args []string) int {
 		ResourceRequestMem: c.flagResourceRequestMem,
 		ResourceLimitCPU:   c.flagResourceLimitCPU,
 		ResourceLimitMem:   c.flagResourceLimitMem,
+		ExitOnRetryFailure: c.flagExitOnRetryFailure,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -30,6 +30,10 @@ type Specification struct {
 	// LogFormat is the AGENT_INJECT_LOG_FORMAT environment variable
 	LogFormat string `split_words:"true"`
 
+	// TemplateConfigExitOnRetryFailure is the
+	// AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE environment variable.
+	TemplateConfigExitOnRetryFailure string `split_words:"true"`
+
 	// TLSAuto is the AGENT_INJECT_TLS_AUTO environment variable.
 	TLSAuto string `envconfig:"tls_auto"`
 
@@ -101,6 +105,8 @@ func (c *Command) init() {
 		`(in order of detail) are "trace", "debug", "info", "warn", and "err".`)
 	c.flagSet.StringVar(&c.flagLogFormat, "log-format", DefaultLogFormat, "Log output format. "+
 		`Supported log formats: "standard", "json".`)
+	c.flagSet.BoolVar(&c.flagExitOnRetryFailure, "template-config-exit-on-retry-failure", agent.DefaultAgentTemplateConfigExitOnRetryFailure,
+		fmt.Sprintf("Value for Agent's template_config.exit_on_retry_failure. Defaults to %t.", agent.DefaultAgentTemplateConfigExitOnRetryFailure))
 	c.flagSet.StringVar(&c.flagAutoName, "tls-auto", "",
 		"MutatingWebhookConfiguration name. If specified, will auto generate cert bundle.")
 	c.flagSet.StringVar(&c.flagAutoHosts, "tls-auto-hosts", "",
@@ -190,6 +196,13 @@ func (c *Command) parseEnvs() error {
 
 	if envs.LogFormat != "" {
 		c.flagLogFormat = envs.LogFormat
+	}
+
+	if envs.TemplateConfigExitOnRetryFailure != "" {
+		c.flagExitOnRetryFailure, err = strconv.ParseBool(envs.TemplateConfigExitOnRetryFailure)
+		if err != nil {
+			return err
+		}
 	}
 
 	if envs.TLSAuto != "" {

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -105,8 +105,8 @@ func (c *Command) init() {
 		`(in order of detail) are "trace", "debug", "info", "warn", and "err".`)
 	c.flagSet.StringVar(&c.flagLogFormat, "log-format", DefaultLogFormat, "Log output format. "+
 		`Supported log formats: "standard", "json".`)
-	c.flagSet.BoolVar(&c.flagExitOnRetryFailure, "template-config-exit-on-retry-failure", agent.DefaultAgentTemplateConfigExitOnRetryFailure,
-		fmt.Sprintf("Value for Agent's template_config.exit_on_retry_failure. Defaults to %t.", agent.DefaultAgentTemplateConfigExitOnRetryFailure))
+	c.flagSet.BoolVar(&c.flagExitOnRetryFailure, "template-config-exit-on-retry-failure", agent.DefaultTemplateConfigExitOnRetryFailure,
+		fmt.Sprintf("Value for Agent's template_config.exit_on_retry_failure. Defaults to %t.", agent.DefaultTemplateConfigExitOnRetryFailure))
 	c.flagSet.StringVar(&c.flagAutoName, "tls-auto", "",
 		"MutatingWebhookConfiguration name. If specified, will auto generate cert bundle.")
 	c.flagSet.StringVar(&c.flagAutoHosts, "tls-auto-hosts", "",

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -165,6 +165,8 @@ func TestCommandEnvBools(t *testing.T) {
 		{env: "AGENT_INJECT_SET_SECURITY_CONTEXT", value: false, cmdPtr: &cmd.flagSetSecurityContext},
 		{env: "AGENT_INJECT_USE_LEADER_ELECTOR", value: true, cmdPtr: &cmd.flagUseLeaderElector},
 		{env: "AGENT_INJECT_USE_LEADER_ELECTOR", value: false, cmdPtr: &cmd.flagUseLeaderElector},
+		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: true, cmdPtr: &cmd.flagExitOnRetryFailure},
+		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: false, cmdPtr: &cmd.flagExitOnRetryFailure},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support for setting Vault Agent's new `template_config.exit_on_retry_failure` introduced in https://github.com/hashicorp/vault/pull/11775. 

A new flag and environment variable, `AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE`, is added to allow this value to be toggled globally. There's also a new annotation, `agent-template-config-exit-on-retry-failure`, on agent-inject to allow for pods to override this value. The default value for this is `true` since we don't want pods being stuck during deployments if any of Agent's templates fail to render.