### PR TITLE
Govcloud irsa support

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -651,7 +651,7 @@ func (a *Agent) getAwsEnvsFromContainer(pod *corev1.Pod) map[string]string {
 	envMap := make(map[string]string)
 	for _, container := range pod.Spec.Containers {
 		for _, env := range container.Env {
-			if env.Name == "AWS_ROLE_ARN" || env.Name == "AWS_WEB_IDENTITY_TOKEN_FILE" {
+			if env.Name == "AWS_ROLE_ARN" || env.Name == "AWS_WEB_IDENTITY_TOKEN_FILE" || env.Name == "AWS_DEFAULT_REGION" || env.Name == "AWS_REGION" {
 				if _, ok := envMap[env.Name]; !ok {
 					envMap[env.Name] = env.Value
 				}

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -66,6 +67,14 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 				Name:  k,
 				Value: v,
 			})
+		}
+		if a.Vault.AuthConfig["region"] != nil {
+			if r, ok := a.Vault.AuthConfig["region"].(string); ok {
+				envs = append(envs, corev1.EnvVar{
+					Name:  "AWS_REGION",
+					Value: r,
+				})
+			}
 		}
 	}
 

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -68,9 +68,6 @@ func TestAwsRegionEnvForAwsAuthMethod(t *testing.T) {
 		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws", AuthConfig: getRegionMap()}},
 			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION"},
 		},
-		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws", AuthConfig: getWrongRegionMap()}},
-			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
-		},
 		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
 			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
 		},
@@ -89,12 +86,6 @@ func TestAwsRegionEnvForAwsAuthMethod(t *testing.T) {
 func getRegionMap() map[string]interface{} {
 	return map[string]interface{}{
 		"region": "us-gov-east-1",
-	}
-}
-
-func getWrongRegionMap() map[string]interface{} {
-	return map[string]interface{}{
-		"region": true,
 	}
 }
 

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -46,7 +46,7 @@ func TestContainerEnvsForIRSA(t *testing.T) {
 	}{
 		{Agent{Pod: testPodWithoutIRSA()}, []string{"VAULT_CONFIG"}},
 		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
-			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
+			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"},
 		},
 	}
 	for _, tt := range envTests {
@@ -65,11 +65,11 @@ func TestAwsRegionEnvForAwsAuthMethod(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws", AuthConfig: getRegionMap()}},
+		{Agent{Pod: testPodWithRegionAnnotation(), Vault: Vault{AuthType: "aws", AuthConfig: getRegionMap()}},
 			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION"},
 		},
 		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
-			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
+			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"},
 		},
 	}
 	for _, item := range input {
@@ -94,6 +94,27 @@ func testPodWithoutIRSA() *corev1.Pod {
 }
 
 func testPodWithIRSA() *corev1.Pod {
+	return testPodWithEnv([]corev1.EnvVar{
+		{
+			Name:  "AWS_ROLE_ARN",
+			Value: "foorole",
+		},
+		{
+			Name:  "AWS_WEB_IDENTITY_TOKEN_FILE",
+			Value: "footoken",
+		},
+		{
+			Name:  "AWS_DEFAULT_REGION",
+			Value: "default-region",
+		},
+		{
+			Name:  "AWS_REGION",
+			Value: "test-region",
+		},
+	})
+}
+
+func testPodWithRegionAnnotation() *corev1.Pod {
 	return testPodWithEnv([]corev1.EnvVar{
 		{
 			Name:  "AWS_ROLE_ARN",

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -65,7 +65,7 @@ func TestAwsRegionEnvForAwsAuthMethod(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{Pod: testPodWithRegionAnnotation(), Vault: Vault{AuthType: "aws", AuthConfig: getRegionMap()}},
+		{Agent{Pod: testPodWithRegionInAuthConfig(), Vault: Vault{AuthType: "aws", AuthConfig: getRegionMap()}},
 			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION"},
 		},
 		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
@@ -114,7 +114,7 @@ func testPodWithIRSA() *corev1.Pod {
 	})
 }
 
-func testPodWithRegionAnnotation() *corev1.Pod {
+func testPodWithRegionInAuthConfig() *corev1.Pod {
 	return testPodWithEnv([]corev1.EnvVar{
 		{
 			Name:  "AWS_ROLE_ARN",


### PR DESCRIPTION
This adds env AWS_REGION based on annotation, vault.hashicorp.com/auth-config-region. This is needed by vault to identify cluster OIDC provider on EKS and enables OIDC auth with aws method on gov-clouds.

Fixes - #244