### PR TITLE
Add annotation for rendered file permission

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -182,6 +182,9 @@ type Secret struct {
 
 	// FilePathAndName is the optional file path and name for the rendered secret file.
 	FilePathAndName string
+
+	// FilePermission is the optional file permission for the rendered secret file
+	FilePermission string
 }
 
 type Vault struct {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -37,6 +37,14 @@ const (
 	// secret-volume-path annotation.
 	AnnotationAgentInjectFile = "vault.hashicorp.com/agent-inject-file"
 
+	// AnnotationAgentInjectFilePermission is the key of the annotation that contains the
+	// permission of the file to create on disk. The name of the
+	// secret is the string after "vault.hashicorp.com/agent-inject-file-permission-", and
+	// should map to the same unique value provided in
+	// "vault.hashicorp.com/agent-inject-secret-". The value is the value of the permission, for
+	// example "0644"
+	AnnotationAgentInjectFilePermission = "vault.hashicorp.com/agent-inject-file-permission"
+
 	// AnnotationAgentInjectTemplate is the key annotation that configures Vault
 	// Agent what template to use for rendering the secrets.  The name
 	// of the template is any unique string after "vault.hashicorp.com/agent-inject-template-",
@@ -458,6 +466,11 @@ func (a *Agent) secrets() []*Secret {
 			file := fmt.Sprintf("%s-%s", AnnotationAgentInjectFile, raw)
 			if val, ok := a.Annotations[file]; ok {
 				s.FilePathAndName = val
+			}
+
+			filePerm := fmt.Sprintf("%s-%s", AnnotationAgentInjectFilePermission, raw)
+			if val, ok := a.Annotations[filePerm]; ok {
+				s.FilePermission = val
 			}
 
 			secrets = append(secrets, s)

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -39,11 +39,11 @@ const (
 
 	// AnnotationAgentInjectFilePermission is the key of the annotation that contains the
 	// permission of the file to create on disk. The name of the
-	// secret is the string after "vault.hashicorp.com/agent-inject-file-permission-", and
+	// secret is the string after "vault.hashicorp.com/agent-inject-perms-", and
 	// should map to the same unique value provided in
 	// "vault.hashicorp.com/agent-inject-secret-". The value is the value of the permission, for
 	// example "0644"
-	AnnotationAgentInjectFilePermission = "vault.hashicorp.com/agent-inject-file-permission"
+	AnnotationAgentInjectFilePermission = "vault.hashicorp.com/agent-inject-perms"
 
 	// AnnotationAgentInjectTemplate is the key annotation that configures Vault
 	// Agent what template to use for rendering the secrets.  The name

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -537,7 +537,7 @@ func TestSecretTemplateFileAnnotations(t *testing.T) {
 	}
 }
 
-func TestSecretCommandAnnotations(t *testing.T) {
+func TestSecretPermissionAnnotations(t *testing.T) {
 	tests := []struct {
 		annotations        map[string]string
 		expectedKey        string
@@ -586,7 +586,7 @@ func TestSecretCommandAnnotations(t *testing.T) {
 	}
 }
 
-func TestSecretPErmissionAnnotations(t *testing.T) {
+func TestSecretCommandAnnotations(t *testing.T) {
 	tests := []struct {
 		annotations     map[string]string
 		expectedKey     string

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -545,14 +545,14 @@ func TestSecretPermissionAnnotations(t *testing.T) {
 	}{
 		{
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-secret-foobar":          "test1",
-				"vault.hashicorp.com/agent-inject-file-permission-foobar": "0600",
+				"vault.hashicorp.com/agent-inject-secret-foobar": "test1",
+				"vault.hashicorp.com/agent-inject-perms-foobar":  "0600",
 			}, "foobar", "0600",
 		},
 		{
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-secret-foobar":           "test2",
-				"vault.hashicorp.com/agent-inject-file-permission-foobar2": "0600",
+				"vault.hashicorp.com/agent-inject-secret-foobar": "test2",
+				"vault.hashicorp.com/agent-inject-perms-foobar2": "0600",
 			}, "foobar", "",
 		},
 	}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -77,6 +77,7 @@ type Template struct {
 	RightDelim     string `json:"right_delimiter,omitempty"`
 	Command        string `json:"command,omitempty"`
 	Source         string `json:"source,omitempty"`
+	Perms          string `json:"perms,omitempty"`
 }
 
 // Listener defines the configuration for Vault Agent Cache Listener
@@ -135,6 +136,9 @@ func (a *Agent) newTemplateConfigs() []*Template {
 			LeftDelim:   "{{",
 			RightDelim:  "}}",
 			Command:     secret.Command,
+		}
+		if secret.FilePermission != "" {
+			tmpl.Perms = secret.FilePermission
 		}
 		templates = append(templates, tmpl)
 	}

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -253,8 +253,8 @@ func TestFilePermission(t *testing.T) {
 		{
 			"just secret",
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
-				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-perms-foo":  "0600",
 			},
 			"0600",
 		},
@@ -268,9 +268,9 @@ func TestFilePermission(t *testing.T) {
 		{
 			"with relative file path",
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
-				"vault.hashicorp.com/agent-inject-file-foo":            "nested/foofile",
-				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":   "nested/foofile",
+				"vault.hashicorp.com/agent-inject-perms-foo":  "0600",
 			},
 			"0600",
 		},
@@ -285,9 +285,9 @@ func TestFilePermission(t *testing.T) {
 		{
 			"with absolute file path",
 			map[string]string{
-				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
-				"vault.hashicorp.com/agent-inject-file-foo":            "/special/volume/foofile",
-				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":   "/special/volume/foofile",
+				"vault.hashicorp.com/agent-inject-perms-foo":  "0600",
 			},
 			"0600",
 		},

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -224,6 +224,9 @@ func TestFilePathAndName(t *testing.T) {
 			}
 
 			agent, err := New(pod, patches)
+			if err != nil {
+				t.Errorf("got error creating agent, shouldn't have: %s", err)
+			}
 			cfg, err := agent.newConfig(true)
 			if err != nil {
 				t.Errorf("got error creating Vault config, shouldn't have: %s", err)
@@ -235,6 +238,95 @@ func TestFilePathAndName(t *testing.T) {
 			}
 			if config.Templates[0].Destination != tt.destination {
 				t.Errorf("wrong destination: %s != %s", config.Templates[0].Destination, tt.destination)
+			}
+		})
+	}
+}
+
+func TestFilePermission(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		permission  string
+	}{
+		{
+			"just secret",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+			},
+			"0600",
+		},
+		{
+			"just secret without permission",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+			},
+			"",
+		},
+		{
+			"with relative file path",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":            "nested/foofile",
+				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+			},
+			"0600",
+		},
+		{
+			"with relative file path without permission",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":   "nested/foofile",
+			},
+			"",
+		},
+		{
+			"with absolute file path",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo":          "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":            "/special/volume/foofile",
+				"vault.hashicorp.com/agent-inject-file-permission-foo": "0600",
+			},
+			"0600",
+		},
+		{
+			"with absolute file path without permission",
+			map[string]string{
+				"vault.hashicorp.com/agent-inject-secret-foo": "db/creds/foo",
+				"vault.hashicorp.com/agent-inject-file-foo":   "/special/volume/foofile",
+			},
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := testPod(tt.annotations)
+			var patches []*jsonpatch.JsonPatchOperation
+
+			agentConfig := basicAgentConfig()
+			err := Init(pod, agentConfig)
+			if err != nil {
+				t.Errorf("got error initialising pod, shouldn't have: %s", err)
+			}
+
+			agent, err := New(pod, patches)
+			if err != nil {
+				t.Errorf("got error creating agent, shouldn't have: %s", err)
+			}
+			cfg, err := agent.newConfig(true)
+			if err != nil {
+				t.Errorf("got error creating Vault config, shouldn't have: %s", err)
+			}
+
+			config := &Config{}
+			if err := json.Unmarshal(cfg, config); err != nil {
+				t.Errorf("got error unmarshalling Vault config, shouldn't have: %s", err)
+			}
+			if config.Templates[0].Perms != tt.permission {
+				t.Errorf("wrong permission: %s != %s", config.Templates[0].Perms, tt.permission)
 			}
 		})
 	}


### PR DESCRIPTION
Add a new annotation to allow the user to set the rendered file permission.

Fixes https://github.com/hashicorp/vault-k8s/issues/136

```
$ make test
go test -race ./...
?       github.com/hashicorp/vault-k8s  [no test files]
ok      github.com/hashicorp/vault-k8s/agent-inject     (cached)
ok      github.com/hashicorp/vault-k8s/agent-inject/agent       0.059s
ok      github.com/hashicorp/vault-k8s/helper/cert      (cached)
?       github.com/hashicorp/vault-k8s/helper/flags     [no test files]
?       github.com/hashicorp/vault-k8s/leader   [no test files]
ok      github.com/hashicorp/vault-k8s/subcommand/injector      (cached)
?       github.com/hashicorp/vault-k8s/subcommand/version       [no test files]
?       github.com/hashicorp/vault-k8s/version  [no test files]
```