### PR TITLE
set GVK on AdmissionReview responses in webhook

### DIFF
--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -177,7 +177,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		},
 		Templates: a.newTemplateConfigs(),
 		TemplateConfig: &TemplateConfig{
-			ExitOnRetryFailure: a.VaultAgentTemplateConfig.ExitOnRetryFailure,
+			ExitOnRetryFailure:         a.VaultAgentTemplateConfig.ExitOnRetryFailure,
 			StaticSecretRenderInterval: a.VaultAgentTemplateConfig.StaticSecretRenderInterval,
 		},
 	}

--- a/deploy/injector-mutating-webhook.yaml
+++ b/deploy/injector-mutating-webhook.yaml
@@ -11,7 +11,7 @@ webhooks:
     sideEffects: None
     admissionReviewVersions:
       - "v1"
-      - "v1beta"
+      - "v1beta1"
     clientConfig:
       service:
         name: vault-agent-injector-svc


### PR DESCRIPTION
- Fixes https://github.com/hashicorp/vault-k8s/issues/294

Specifying multiple admissionReviewVersions in webhook config with v1 as the first version causes untyped (no GVK) AdmissionReview responses to fail with an error: 

`failed calling webhook \"vault.hashicorp.com\": expected webhook response of admission.k8s.io/v1, Kind=AdmissionReview, got /, Kind="`

This error results from the kube-apiserver checking response type for v1.AdmissionReview's but not for v1beta1's. Hence, set the AdmissionReview response object's GVK to the request's type if it exists or defaulting to v1.  with this change, either`admissionReviewVersions: ["v1beta1", "v1"]` or `admissionReviewVersions: ["v1", "v1beta1"]` in webhookconfiguration spec works correctly as expected.

- Also fix a typo in `deploy/injector-mutating-webhook.yaml` manifest.