### PR TITLE
TLS server options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Improvements:
+* Added options for setting the TLS minimum version (default 1.2) and supported cipher suites: [GH-302](https://github.com/hashicorp/vault-k8s/pull/302)
+
 ## 0.13.1 (September 29, 2021)
 
 Changes:

--- a/go.mod
+++ b/go.mod
@@ -37,12 +37,16 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/hashicorp/go-hclog v0.9.2
+	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1
 	github.com/hashicorp/vault/sdk v0.1.14-0.20191205220236-47cffd09f972
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kr/text v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -239,7 +239,14 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1 h1:78ki3QBevHwYrVxnyVeaEz+7WtifHhauYF23es/0KlI=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
+github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1 h1:Yc026VyMyIpq1UWRnakHRG01U8fJm+nEfEmjoAb00n8=
+github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
+github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -334,6 +341,8 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -37,35 +37,34 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flagListen                      string // Address of Vault Server
-	flagLogLevel                    string // Log verbosity
-	flagLogFormat                   string // Log format
-	flagCertFile                    string // TLS Certificate to serve
-	flagKeyFile                     string // TLS private key to serve
-	flagExitOnRetryFailure          bool   // Set template_config.exit_on_retry_failure on agent
-	flagStaticSecretRenderInterval  string // Set template_config.static_secret_render_interval on agent
-	flagAutoName                    string // MutatingWebhookConfiguration for updating
-	flagAutoHosts                   string // SANs for the auto-generated TLS cert.
-	flagVaultService                string // Name of the Vault service
-	flagProxyAddress                string // HTTP proxy address used to talk to the Vault service
-	flagVaultImage                  string // Name of the Vault Image to use
-	flagVaultAuthType               string // Type of Vault Auth Method to use
-	flagVaultAuthPath               string // Mount path of the Vault Auth Method
-	flagRevokeOnShutdown            bool   // Revoke Vault Token on pod shutdown
-	flagRunAsUser                   string // User (uid) to run Vault agent as
-	flagRunAsGroup                  string // Group (gid) to run Vault agent as
-	flagRunAsSameUser               bool   // Run Vault agent as the User (uid) of the first application container
-	flagSetSecurityContext          bool   // Set SecurityContext in injected containers
-	flagTelemetryPath               string // Path under which to expose metrics
-	flagUseLeaderElector            bool   // Use leader elector code
-	flagDefaultTemplate             string // Toggles which default template to use
-	flagResourceRequestCPU          string // Set CPU request in the injected containers
-	flagResourceRequestMem          string // Set Memory request in the injected containers
-	flagResourceLimitCPU            string // Set CPU limit in the injected containers
-	flagResourceLimitMem            string // Set Memory limit in the injected containers
-	flagTLSMinVersion               string // Minimum TLS version supported by the webhook server
-	flagTLSCipherSuites             string // Comma-separated list of supported cipher suites
-	flagTLSPreferServerCipherSuites bool   // Prefer this server's cipher suites over the client cipher suites
+	flagListen                     string // Address of Vault Server
+	flagLogLevel                   string // Log verbosity
+	flagLogFormat                  string // Log format
+	flagCertFile                   string // TLS Certificate to serve
+	flagKeyFile                    string // TLS private key to serve
+	flagExitOnRetryFailure         bool   // Set template_config.exit_on_retry_failure on agent
+	flagStaticSecretRenderInterval string // Set template_config.static_secret_render_interval on agent
+	flagAutoName                   string // MutatingWebhookConfiguration for updating
+	flagAutoHosts                  string // SANs for the auto-generated TLS cert.
+	flagVaultService               string // Name of the Vault service
+	flagProxyAddress               string // HTTP proxy address used to talk to the Vault service
+	flagVaultImage                 string // Name of the Vault Image to use
+	flagVaultAuthType              string // Type of Vault Auth Method to use
+	flagVaultAuthPath              string // Mount path of the Vault Auth Method
+	flagRevokeOnShutdown           bool   // Revoke Vault Token on pod shutdown
+	flagRunAsUser                  string // User (uid) to run Vault agent as
+	flagRunAsGroup                 string // Group (gid) to run Vault agent as
+	flagRunAsSameUser              bool   // Run Vault agent as the User (uid) of the first application container
+	flagSetSecurityContext         bool   // Set SecurityContext in injected containers
+	flagTelemetryPath              string // Path under which to expose metrics
+	flagUseLeaderElector           bool   // Use leader elector code
+	flagDefaultTemplate            string // Toggles which default template to use
+	flagResourceRequestCPU         string // Set CPU request in the injected containers
+	flagResourceRequestMem         string // Set Memory request in the injected containers
+	flagResourceLimitCPU           string // Set CPU limit in the injected containers
+	flagResourceLimitMem           string // Set Memory limit in the injected containers
+	flagTLSMinVersion              string // Minimum TLS version supported by the webhook server
+	flagTLSCipherSuites            string // Comma-separated list of supported cipher suites
 
 	flagSet *flag.FlagSet
 
@@ -287,9 +286,8 @@ func (c *Command) makeTLSConfig() (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{
-		GetCertificate:           c.getCertificate,
-		MinVersion:               minTLSVersion,
-		PreferServerCipherSuites: c.flagTLSPreferServerCipherSuites,
+		GetCertificate: c.getCertificate,
+		MinVersion:     minTLSVersion,
 	}
 	if len(ciphers) > 0 {
 		tlsConfig.CipherSuites = ciphers

--- a/subcommand/injector/command_test.go
+++ b/subcommand/injector/command_test.go
@@ -1,0 +1,61 @@
+package injector
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTLSConfig(t *testing.T) {
+	tests := map[string]struct {
+		tlsVersion    string
+		suites        string
+		expectedError error
+	}{
+		"defaults": {
+			tlsVersion:    defaultTLSMinVersion,
+			suites:        "",
+			expectedError: nil,
+		},
+		"bad tls": {
+			tlsVersion:    "tls1000",
+			suites:        "",
+			expectedError: fmt.Errorf(`invalid or unsupported TLS version "tls1000"`),
+		},
+		"non-default tls": {
+			tlsVersion:    "tls13",
+			suites:        "",
+			expectedError: nil,
+		},
+		"suites specified": {
+			tlsVersion:    defaultTLSMinVersion,
+			suites:        "TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384",
+			expectedError: nil,
+		},
+		"invalid suites specified": {
+			tlsVersion:    defaultTLSMinVersion,
+			suites:        "suite1,suite2,suite3",
+			expectedError: fmt.Errorf(`failed to parse TLS cipher suites list "suite1,suite2,suite3": unsupported cipher "suite1"`),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Command{}
+			c.flagTLSMinVersion = tc.tlsVersion
+			c.flagTLSCipherSuites = tc.suites
+			result, err := c.makeTLSConfig()
+			assert.Equal(t, tc.expectedError, err)
+			if tc.expectedError == nil {
+				assert.NotZero(t, result.MinVersion)
+				if len(tc.suites) == 0 {
+					assert.Nil(t, result.CipherSuites)
+				} else {
+					assert.Len(t, result.CipherSuites, len(strings.Split(tc.suites, ",")))
+				}
+			}
+		})
+	}
+}

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -3,10 +3,12 @@ package injector
 import (
 	"flag"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/vault-k8s/agent-inject/agent"
 	"github.com/hashicorp/vault-k8s/helper/flags"
 	"github.com/kelseyhightower/envconfig"
@@ -167,8 +169,14 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagResourceLimitMem, "memory-limit", agent.DefaultResourceLimitMem,
 		fmt.Sprintf("Memory resource limit set in injected containers. Defaults to %s", agent.DefaultResourceLimitMem))
 
+	tlsVersions := []string{}
+	for v := range tlsutil.TLSLookup {
+		tlsVersions = append(tlsVersions, v)
+	}
+	sort.Strings(tlsVersions)
+	tlsStr := strings.Join(tlsVersions, ", ")
 	c.flagSet.StringVar(&c.flagTLSMinVersion, "tls-min-version", defaultTLSMinVersion,
-		fmt.Sprintf(`Minimum supported version of TLS. Defaults to %s. Accepted values are "tls10", "tls11", "tls12" or "tls13"`, defaultTLSMinVersion))
+		fmt.Sprintf(`Minimum supported version of TLS. Defaults to %s. Accepted values are %s.`, defaultTLSMinVersion, tlsStr))
 	c.flagSet.StringVar(&c.flagTLSCipherSuites, "tls-cipher-suites", "",
 		"Comma-separated list of supported cipher suites")
 

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	DefaultLogLevel                    = "info"
-	DefaultLogFormat                   = "standard"
-	defaultTLSMinVersion               = "tls12"
-	defaultTLSPreferServerCipherSuites = true
+	DefaultLogLevel      = "info"
+	DefaultLogFormat     = "standard"
+	defaultTLSMinVersion = "tls12"
 )
 
 // Specification are the supported environment variables, prefixed with
@@ -108,9 +107,6 @@ type Specification struct {
 
 	// TLSCipherSuites is the AGENT_INJECT_TLS_CIPHER_SUITES environment variable
 	TLSCipherSuites string `envconfig:"tls_cipher_suites"`
-
-	// TLSPreferServerCipherSuites is the AGENT_INJECT_TLS_PREFER_SERVER_CIPHER_SUITES environment variable
-	TLSPreferServerCipherSuites string `envconfig:"tls_prefer_server_cipher_suites"`
 }
 
 func (c *Command) init() {
@@ -175,8 +171,6 @@ func (c *Command) init() {
 		fmt.Sprintf(`Minimum supported version of TLS. Defaults to %s. Accepted values are "tls10", "tls11", "tls12" or "tls13"`, defaultTLSMinVersion))
 	c.flagSet.StringVar(&c.flagTLSCipherSuites, "tls-cipher-suites", "",
 		"Comma-separated list of supported cipher suites")
-	c.flagSet.BoolVar(&c.flagTLSPreferServerCipherSuites, "tls-prefer-server-cipher-suites", defaultTLSPreferServerCipherSuites,
-		fmt.Sprintf("Prefer the server's cipher suites over the client cipher suites. Defaults to %v", defaultTLSPreferServerCipherSuites))
 
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -335,13 +329,6 @@ func (c *Command) parseEnvs() error {
 
 	if envs.TLSCipherSuites != "" {
 		c.flagTLSCipherSuites = envs.TLSCipherSuites
-	}
-
-	if envs.TLSPreferServerCipherSuites != "" {
-		c.flagTLSPreferServerCipherSuites, err = strconv.ParseBool(envs.TLSPreferServerCipherSuites)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -178,7 +178,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagTLSMinVersion, "tls-min-version", defaultTLSMinVersion,
 		fmt.Sprintf(`Minimum supported version of TLS. Defaults to %s. Accepted values are %s.`, defaultTLSMinVersion, tlsStr))
 	c.flagSet.StringVar(&c.flagTLSCipherSuites, "tls-cipher-suites", "",
-		"Comma-separated list of supported cipher suites")
+		"Comma-separated list of supported cipher suites for TLS 1.0-1.2")
 
 	c.help = flags.Usage(help, c.flagSet)
 }

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -170,8 +170,6 @@ func TestCommandEnvBools(t *testing.T) {
 		{env: "AGENT_INJECT_USE_LEADER_ELECTOR", value: false, cmdPtr: &cmd.flagUseLeaderElector},
 		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: true, cmdPtr: &cmd.flagExitOnRetryFailure},
 		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: false, cmdPtr: &cmd.flagExitOnRetryFailure},
-		{env: "AGENT_INJECT_TLS_PREFER_SERVER_CIPHER_SUITES", value: true, cmdPtr: &cmd.flagTLSPreferServerCipherSuites},
-		{env: "AGENT_INJECT_TLS_PREFER_SERVER_CIPHER_SUITES", value: false, cmdPtr: &cmd.flagTLSPreferServerCipherSuites},
 	}
 
 	for _, tt := range tests {

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -131,6 +131,8 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_CPU_LIMIT", value: "1000m", cmdPtr: &cmd.flagResourceLimitCPU},
 		{env: "AGENT_INJECT_MEM_LIMIT", value: "256m", cmdPtr: &cmd.flagResourceLimitMem},
 		{env: "AGENT_INJECT_TEMPLATE_STATIC_SECRET_RENDER_INTERVAL", value: "12s", cmdPtr: &cmd.flagStaticSecretRenderInterval},
+		{env: "AGENT_INJECT_TLS_MIN_VERSION", value: "tls13", cmdPtr: &cmd.flagTLSMinVersion},
+		{env: "AGENT_INJECT_TLS_CIPHER_SUITES", value: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", cmdPtr: &cmd.flagTLSCipherSuites},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +170,8 @@ func TestCommandEnvBools(t *testing.T) {
 		{env: "AGENT_INJECT_USE_LEADER_ELECTOR", value: false, cmdPtr: &cmd.flagUseLeaderElector},
 		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: true, cmdPtr: &cmd.flagExitOnRetryFailure},
 		{env: "AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE", value: false, cmdPtr: &cmd.flagExitOnRetryFailure},
+		{env: "AGENT_INJECT_TLS_PREFER_SERVER_CIPHER_SUITES", value: true, cmdPtr: &cmd.flagTLSPreferServerCipherSuites},
+		{env: "AGENT_INJECT_TLS_PREFER_SERVER_CIPHER_SUITES", value: false, cmdPtr: &cmd.flagTLSPreferServerCipherSuites},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds options for setting the TLS minimum version and supported cipher suites. Each can be set via command-line flag or environment variable.

| Environment variable | command-line flag | default | allowed values |
| --------------------  | ---------------- | ------- | ------------ |
| AGENT_INJECT_TLS_MIN_VERSION | -tls-min-version | tls12 | tls10 tls11 tls12 tls13 |
| AGENT_INJECT_TLS_CIPHER_SUITES | -tls-cipher-suites | "" | comma-separated list of cipher suites from the [available ciphersuites](https://github.com/hashicorp/go-secure-stdlib/blob/tlsutil/v0.1.1/tlsutil/tlsutil.go#L26-L53)

When deploying with vault-helm, these can be set using the [injector.extraEnvironmentVariables](https://www.vaultproject.io/docs/platform/k8s/helm/configuration#extraenvironmentvars) chart option. 

Requires https://github.com/hashicorp/vault-k8s/pull/303 since this PR assumes [tls `Config.PreferServerCipherSuites` is ignored/deprecated](https://pkg.go.dev/crypto/tls#Config) as it is in go 1.17.