### PR TITLE
Mirror pod container env vars on sidecars, unless duplicates

### DIFF
--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -78,5 +78,21 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 		}
 	}
 
+	// Mirror pod container envs, but don't overwrite ones we added above,
+	// and no duplicates
+	if a.Pod != nil && a.Pod.Spec.Containers != nil {
+		for _, c := range a.Pod.Spec.Containers {
+		envVars:
+			for _, e := range c.Env {
+				for _, v := range envs {
+					if v.Name == e.Name {
+						continue envVars
+					}
+				}
+				envs = append(envs, *e.DeepCopy())
+			}
+		}
+	}
+
 	return envs, nil
 }


### PR DESCRIPTION
This mirrors the env vars from all containers in the pod to the sidecar containers, but will not overwrite any env vars that Vault Agent adds, or otherwise duplicates.  It fixes my issue, and I believe it also may fix #161 .
