### PR TITLE
fixing changelog link text for #250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@ Improvements:
 ## 0.10.1 (May 25, 2021)
 
 Bugs:
-* Fix agent-inject-token when caching enabled: [GH-290](https://github.com/hashicorp/vault-k8s/pull/250)
-* Remove new line from injected token: [GH-290](https://github.com/hashicorp/vault-k8s/pull/250)
+* Fix agent-inject-token when caching enabled: [GH-250](https://github.com/hashicorp/vault-k8s/pull/250)
+* Remove new line from injected token: [GH-250](https://github.com/hashicorp/vault-k8s/pull/250)
 
 ## 0.10.0 (April 14, 2021)
 


### PR DESCRIPTION
It was erroneously set to 290 instead of 250.