### PR TITLE
Build with go 1.17.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.8
 
       - name: Build
         run: make build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Features:
 * Add agent-inject-containers annotation [GH-313](https://github.com/hashicorp/vault-k8s/pull/313)
 
+Changes:
+* Build with go 1.17.8
+
 ## 0.14.2 (January 19, 2022)
 
 Changes:


### PR DESCRIPTION
Build with go 1.17.8 

Release history: https://go.dev/doc/devel/release#go1.17.minor

Not sure if this is the only change required, let me know if more changes are required.
 