### PR TITLE
Add agent metrics annotations & env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.16.0 (March 30, 2022)
+
+Features:
+* New environment variable and annotation to configure metrics listener address for Vault agent
+* New environment variable and annotation to enable prometheus metrics and configure retention time for Vault agent
+
 ## 0.15.0 (March 21, 2022)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 0.16.0 (March 30, 2022)
 
 Features:
-* New environment variable and annotation to configure metrics listener address for Vault agent
-* New environment variable and annotation to enable prometheus metrics and configure retention time for Vault agent
+* New environment variables and annotations to configure metrics on Vault agent [GH-329](https://github.com/hashicorp/vault-k8s/pull/329)
 
 ## 0.15.0 (March 21, 2022)
 

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -732,6 +732,10 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		{AnnotationAgentCacheEnable, "tRuE", false},
 		{AnnotationAgentCacheEnable, "fAlSe", false},
 		{AnnotationAgentCacheEnable, "", false},
+
+		{AnnotationAgentMetricsListenerAddress, "127.0.0.1", true},
+		{AnnotationAgentMetricsListenerAddress, "127.0.0.1:8080", true},
+		{AnnotationAgentMetricsListenerAddress, "127.0.01:1:1", false},
 	}
 
 	for i, tt := range tests {

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -64,6 +64,8 @@ type Handler struct {
 	ResourceLimitMem           string
 	ExitOnRetryFailure         bool
 	StaticSecretRenderInterval string
+	MetricsListenerAddress     string
+	MetricsPrometheusRetention string
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -194,6 +196,8 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		ResourceLimitMem:           h.ResourceLimitMem,
 		ExitOnRetryFailure:         h.ExitOnRetryFailure,
 		StaticSecretRenderInterval: h.StaticSecretRenderInterval,
+		MetricsListenerAddress:     h.MetricsListenerAddress,
+		MetricsPrometheusRetention: h.MetricsPrometheusRetention,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -56,7 +56,7 @@ type Command struct {
 	flagRunAsGroup                 string // Group (gid) to run Vault agent as
 	flagRunAsSameUser              bool   // Run Vault agent as the User (uid) of the first application container
 	flagSetSecurityContext         bool   // Set SecurityContext in injected containers
-	flagTelemetryPath              string // Path under which to expose metrics
+	flagTelemetryPath              string // Path under which to expose Agent Injector metrics
 	flagUseLeaderElector           bool   // Use leader elector code
 	flagDefaultTemplate            string // Toggles which default template to use
 	flagResourceRequestCPU         string // Set CPU request in the injected containers
@@ -65,6 +65,8 @@ type Command struct {
 	flagResourceLimitMem           string // Set Memory limit in the injected containers
 	flagTLSMinVersion              string // Minimum TLS version supported by the webhook server
 	flagTLSCipherSuites            string // Comma-separated list of supported cipher suites
+	flagMetricsListenerAddress     string // Enables and defines a default listener address for Vault agent
+	flagMetricsPrometheusRetention string // Enables prometheus metrics and defines a default retention period for Vault agent
 
 	flagSet *flag.FlagSet
 
@@ -197,6 +199,8 @@ func (c *Command) Run(args []string) int {
 		ResourceLimitMem:           c.flagResourceLimitMem,
 		ExitOnRetryFailure:         c.flagExitOnRetryFailure,
 		StaticSecretRenderInterval: c.flagStaticSecretRenderInterval,
+		MetricsListenerAddress:     c.flagMetricsListenerAddress,
+		MetricsPrometheusRetention: c.flagMetricsPrometheusRetention,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -109,6 +109,12 @@ type Specification struct {
 
 	// TLSCipherSuites is the AGENT_INJECT_TLS_CIPHER_SUITES environment variable
 	TLSCipherSuites string `envconfig:"tls_cipher_suites"`
+
+	// MetricsListenerAddress is the AGENT_INJECT_METRICS_LISTENER_ADDR environment variable
+	MetricsListenerAddr string `split_words:"true"`
+
+	// MetricsPrometheusRetention is the AGENT_INJECT_METRICS_PROMETHEUS_RETENTION environment variable
+	MetricsPrometheusRetention string `split_words:"true"`
 }
 
 func (c *Command) init() {
@@ -153,7 +159,7 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagSetSecurityContext, "set-security-context", agent.DefaultAgentSetSecurityContext,
 		fmt.Sprintf("Set SecurityContext in injected containers. Defaults to %v.", agent.DefaultAgentSetSecurityContext))
 	c.flagSet.StringVar(&c.flagTelemetryPath, "telemetry-path", "",
-		"Path under which to expose metrics")
+		"Path under which to expose Agent Injector metrics")
 	c.flagSet.BoolVar(&c.flagUseLeaderElector, "use-leader-elector", agent.DefaultAgentUseLeaderElector,
 		"Use leader elector to coordinate multiple replicas when updating CA and Certs with auto-tls")
 	c.flagSet.StringVar(&c.flagDefaultTemplate, "default-template", agent.DefaultTemplateType,
@@ -179,6 +185,11 @@ func (c *Command) init() {
 		fmt.Sprintf(`Minimum supported version of TLS. Defaults to %s. Accepted values are %s.`, defaultTLSMinVersion, tlsStr))
 	c.flagSet.StringVar(&c.flagTLSCipherSuites, "tls-cipher-suites", "",
 		"Comma-separated list of supported cipher suites for TLS 1.0-1.2")
+
+	c.flagSet.StringVar(&c.flagMetricsListenerAddress, "metrics-listener-address", "",
+		"Enables and defines a default listener address for Vault agent")
+	c.flagSet.StringVar(&c.flagMetricsPrometheusRetention, "metrics-prometheus-retention", "",
+		"Enables prometheus metrics and defines a default retention period for Vault agent")
 
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -337,6 +348,14 @@ func (c *Command) parseEnvs() error {
 
 	if envs.TLSCipherSuites != "" {
 		c.flagTLSCipherSuites = envs.TLSCipherSuites
+	}
+
+	if envs.MetricsListenerAddr != "" {
+		c.flagMetricsListenerAddress = envs.MetricsListenerAddr
+	}
+
+	if envs.MetricsPrometheusRetention != "" {
+		c.flagMetricsPrometheusRetention = envs.MetricsPrometheusRetention
 	}
 
 	return nil


### PR DESCRIPTION
Now that Vault Agent metrics have been released in v1.10.0 (https://github.com/hashicorp/vault/pull/13675), the injector needs a way to enable and configure them. There is a strong need for those using the Vault Injector in production to have insights on Vault authentication/ connection issues from the injected agent. This pull request addresses #331.

A few notes on this pull request:
- Annotations have not been added for setting up server-side TLS on the exposed metrics address; this would be a great feature to add later. If there is a strict requirement for TLS right now, this can still be achieved either via a service mesh or by setting the metrics address to localhost for a custom application to consume and expose on its own terms.
- Until https://github.com/hashicorp/vault/issues/8953 is resolved, an empty cache block will be added as a temporary workaround to the configuration if a cache configuration isn't provided already
- The "vault agent -config" command currently adds cache endpoints to all listeners regardless of their purpose, which can create an unintentionally insecure configuration if a user only wants to expose a metrics endpoint externally. Until this issue is resolved on the Vault Agent, a temporary safeguard has been implemented that prevents users with auto-auth configured on the cache from also configuring an external metrics listening address.