### PR TITLE
add agent-enable-quit annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* Add agent-enable-quit annotation [GH-330](https://github.com/hashicorp/vault-k8s/pull/330)
+
 ## 0.15.0 (March 21, 2022)
 
 Features:

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -158,6 +158,10 @@ type Agent struct {
 	// InjectToken controls whether the auto-auth token is injected into the
 	// secrets volume (e.g. /vault/secrets/token)
 	InjectToken bool
+
+	// EnableQuit controls whether the quit endpoint is enabled on a localhost
+	// listener
+	EnableQuit *bool
 }
 
 type ServiceAccountTokenVolume struct {
@@ -439,6 +443,11 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 	agent.VaultAgentTemplateConfig = VaultAgentTemplateConfig{
 		ExitOnRetryFailure:         exitOnRetryFailure,
 		StaticSecretRenderInterval: pod.Annotations[AnnotationTemplateConfigStaticSecretRenderInterval],
+	}
+
+	agent.EnableQuit, err = agent.getEnableQuit()
+	if err != nil {
+		return nil, err
 	}
 
 	return agent, nil

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -33,6 +33,7 @@ const (
 	DefaultAgentInjectToken                 = false
 	DefaultTemplateConfigExitOnRetryFailure = true
 	DefaultServiceAccountMount              = "/var/run/secrets/vault.hashicorp.com/serviceaccount"
+	DefaultEnableQuit                       = false
 )
 
 // Agent is the top level structure holding all the
@@ -161,7 +162,7 @@ type Agent struct {
 
 	// EnableQuit controls whether the quit endpoint is enabled on a localhost
 	// listener
-	EnableQuit *bool
+	EnableQuit bool
 }
 
 type ServiceAccountTokenVolume struct {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -649,16 +649,12 @@ func (a *Agent) templateConfigExitOnRetryFailure() (bool, error) {
 	return strconv.ParseBool(raw)
 }
 
-func (a *Agent) getEnableQuit() (*bool, error) {
+func (a *Agent) getEnableQuit() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentEnableQuit]
 	if !ok {
-		return nil, nil
+		return DefaultEnableQuit, nil
 	}
-	val, err := strconv.ParseBool(raw)
-	if err != nil {
-		return nil, err
-	}
-	return &val, nil
+	return strconv.ParseBool(raw)
 }
 
 func (a *Agent) cachePersist(cacheEnabled bool) bool {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -255,6 +255,10 @@ const (
 	// If specified, configures how often Vault Agent Template should render non-leased secrets such as KV v2.
 	// Defaults to 5 minutes.
 	AnnotationTemplateConfigStaticSecretRenderInterval = "vault.hashicorp.com/template-static-secret-render-interval"
+
+	// AnnotationAgentEnableQuit configures whether the quit endpoint is
+	// enabled in the injected agent config
+	AnnotationAgentEnableQuit = "vault.hashicorp.com/agent-enable-quit"
 )
 
 type AgentConfig struct {
@@ -439,6 +443,7 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigExitOnRetryFailure]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationTemplateConfigExitOnRetryFailure] = strconv.FormatBool(cfg.ExitOnRetryFailure)
 	}
+
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigStaticSecretRenderInterval]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationTemplateConfigStaticSecretRenderInterval] = cfg.StaticSecretRenderInterval
 	}
@@ -642,6 +647,18 @@ func (a *Agent) templateConfigExitOnRetryFailure() (bool, error) {
 	}
 
 	return strconv.ParseBool(raw)
+}
+
+func (a *Agent) getEnableQuit() (*bool, error) {
+	raw, ok := a.Annotations[AnnotationAgentEnableQuit]
+	if !ok {
+		return nil, nil
+	}
+	val, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &val, nil
 }
 
 func (a *Agent) cachePersist(cacheEnabled bool) bool {

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -215,24 +215,21 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		}
 	}
 
-	// If EnableQuit has been set, set it on the listener. If a listener hasn't
-	// been defined, set it on a new one. Also add a simple cache stanza since
-	// that's required for an agent listener.
-	if a.EnableQuit != nil {
+	// If EnableQuit is true, set it on the listener. If a listener hasn't been
+	// defined, set it on a new one. Also add a simple cache stanza since that's
+	// required for an agent listener.
+	if a.EnableQuit {
 		if len(config.Listener) > 0 {
 			config.Listener[0].AgentAPI = &AgentAPI{
-				EnableQuit: *a.EnableQuit,
+				EnableQuit: a.EnableQuit,
 			}
 		} else {
-			// Only setup a new listener if EnableQuit is true
-			if *a.EnableQuit {
-				config.Listener = makeCacheListener(a.VaultAgentCache.ListenerPort)
-				config.Listener[0].AgentAPI = &AgentAPI{
-					EnableQuit: *a.EnableQuit,
-				}
+			config.Listener = makeCacheListener(a.VaultAgentCache.ListenerPort)
+			config.Listener[0].AgentAPI = &AgentAPI{
+				EnableQuit: a.EnableQuit,
 			}
 		}
-		if *a.EnableQuit && config.Cache == nil {
+		if config.Cache == nil {
 			// Cache is required for an agent listener
 			config.Cache = &Cache{}
 		}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -95,7 +95,7 @@ type AgentAPI struct {
 
 // Cache defines the configuration for the Vault Agent Cache
 type Cache struct {
-	UseAutoAuthToken string        `json:"use_auto_auth_token"`
+	UseAutoAuthToken string        `json:"use_auto_auth_token,omitempty"`
 	Persist          *CachePersist `json:"persist,omitempty"`
 }
 

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -82,9 +82,15 @@ type Template struct {
 
 // Listener defines the configuration for Vault Agent Cache Listener
 type Listener struct {
-	Type       string `json:"type"`
-	Address    string `json:"address"`
-	TLSDisable bool   `json:"tls_disable"`
+	Type       string    `json:"type"`
+	Address    string    `json:"address"`
+	TLSDisable bool      `json:"tls_disable"`
+	AgentAPI   *AgentAPI `json:"agent_api,omitempty"`
+}
+
+// AgentAPI defines the agent_api stanza for a listener
+type AgentAPI struct {
+	EnableQuit bool `json:"enable_quit"`
 }
 
 // Cache defines the configuration for the Vault Agent Cache
@@ -191,13 +197,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		})
 	}
 
-	cacheListener := []*Listener{
-		{
-			Type:       "tcp",
-			Address:    fmt.Sprintf("127.0.0.1:%s", a.VaultAgentCache.ListenerPort),
-			TLSDisable: true,
-		},
-	}
+	cacheListener := makeCacheListener(a.VaultAgentCache.ListenerPort)
 	if a.VaultAgentCache.Persist {
 		config.Listener = cacheListener
 		config.Cache = &Cache{
@@ -215,9 +215,42 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		}
 	}
 
+	// If EnableQuit has been set, set it on the listener. If a listener hasn't
+	// been defined, set it on a new one. Also add a simple cache stanza since
+	// that's required for an agent listener.
+	if a.EnableQuit != nil {
+		if len(config.Listener) > 0 {
+			config.Listener[0].AgentAPI = &AgentAPI{
+				EnableQuit: *a.EnableQuit,
+			}
+		} else {
+			// Only setup a new listener if EnableQuit is true
+			if *a.EnableQuit {
+				config.Listener = makeCacheListener(a.VaultAgentCache.ListenerPort)
+				config.Listener[0].AgentAPI = &AgentAPI{
+					EnableQuit: *a.EnableQuit,
+				}
+			}
+		}
+		if *a.EnableQuit && config.Cache == nil {
+			// Cache is required for an agent listener
+			config.Cache = &Cache{}
+		}
+	}
+
 	return config.render()
 }
 
 func (c *Config) render() ([]byte, error) {
 	return json.Marshal(c)
+}
+
+func makeCacheListener(port string) []*Listener {
+	return []*Listener{
+		{
+			Type:       "tcp",
+			Address:    fmt.Sprintf("127.0.0.1:%s", port),
+			TLSDisable: true,
+		},
+	}
 }

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -696,9 +696,7 @@ func TestConfigAgentQuit(t *testing.T) {
 		},
 		{
 			"enable_quit false with no cache listener",
-			map[string]string{
-				AnnotationAgentEnableQuit: "false",
-			},
+			nil,
 			nil,
 			fmt.Sprintf("127.0.0.1:%s", DefaultAgentCacheListenerPort),
 			nil,
@@ -725,7 +723,7 @@ func TestConfigAgentQuit(t *testing.T) {
 				AnnotationAgentCacheEnable: "true",
 				AnnotationAgentEnableQuit:  "false",
 			},
-			&AgentAPI{EnableQuit: false},
+			nil,
 			fmt.Sprintf("127.0.0.1:%s", DefaultAgentCacheListenerPort),
 			&Cache{
 				UseAutoAuthToken: "true",


### PR DESCRIPTION
New annotation to enable the [/agent/v1/quit endpoint](https://www.vaultproject.io/docs/agent#quit) on an injected agent. This option defaults to `false`, and will be set if `true` on the existing cache listener, or a new localhost listener with a basic cache stanza configured since that's required for an agent listener.

The [agent-cache-listener-port](https://www.vaultproject.io/docs/platform/k8s/injector/annotations#vault-hashicorp-com-agent-cache-listener-port) annotation can be used to change the port.

Example Job:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: quit

spec:
  template:
    metadata:
      annotations:
        vault.hashicorp.com/agent-inject: "true"
        vault.hashicorp.com/role: "internal-app"
        vault.hashicorp.com/agent-inject-secret-database-config.txt: "internal/data/database/config"
        vault.hashicorp.com/agent-inject-template-database-config.txt: |
          {{- with secret "internal/data/database/config" -}}
          postgresql://{{ .Data.data.username }}:{{ .Data.data.password }}@postgres:5432/wizard
          {{- end -}}
        vault.hashicorp.com/agent-enable-quit: "true"
    spec:
      serviceAccountName: internal-app
      containers:
      - name: nginx
        image: nginx
        command: ["/bin/bash", "-c"]
        args:
          - |
            sleep 10
            curl -X POST http://localhost:8200/agent/v1/quit

      restartPolicy: Never
  backoffLimit: 4
```