### PR TITLE
add go-max-procs annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Features:
 * Add agent-enable-quit annotation [GH-330](https://github.com/hashicorp/vault-k8s/pull/330)
+* Add go-max-procs annotation [GH-333](https://github.com/hashicorp/vault-k8s/pull/333)
 
 ## 0.15.0 (March 21, 2022)
 

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -244,6 +244,9 @@ type Vault struct {
 	// make a request to the Vault server.
 	ClientTimeout string
 
+	// GoMaxProcs sets the Vault Agent go max procs.
+	GoMaxProcs string
+
 	// LogLevel sets the Vault Agent log level.  Defaults to info.
 	LogLevel string
 
@@ -337,6 +340,7 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 			ClientKey:        pod.Annotations[AnnotationVaultClientKey],
 			ClientMaxRetries: pod.Annotations[AnnotationVaultClientMaxRetries],
 			ClientTimeout:    pod.Annotations[AnnotationVaultClientTimeout],
+			GoMaxProcs:       pod.Annotations[AnnotationVaultGoMaxProcs],
 			LogLevel:         pod.Annotations[AnnotationVaultLogLevel],
 			LogFormat:        pod.Annotations[AnnotationVaultLogFormat],
 			Namespace:        pod.Annotations[AnnotationVaultNamespace],

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -197,6 +197,9 @@ const (
 	// AnnotationVaultClientTimeout sets the request timeout when communicating with Vault.
 	AnnotationVaultClientTimeout = "vault.hashicorp.com/client-timeout"
 
+	// AnnotationVaultGoMaxProcs sets the Vault Agent go max procs.
+	AnnotationVaultGoMaxProcs = "vault.hashicorp.com/go-max-procs"
+
 	// AnnotationVaultLogLevel sets the Vault Agent log level.
 	AnnotationVaultLogLevel = "vault.hashicorp.com/log-level"
 

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -11,6 +11,13 @@ import (
 func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 	var envs []corev1.EnvVar
 
+	if a.Vault.GoMaxProcs != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "GOMAXPROCS",
+			Value: a.Vault.GoMaxProcs,
+		})
+	}
+
 	if a.Vault.ClientTimeout != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLIENT_TIMEOUT",

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -20,6 +20,7 @@ func TestContainerEnvs(t *testing.T) {
 		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
+		{Agent{Vault: Vault{GoMaxProcs: "1"}}, []string{"VAULT_CONFIG", "GOMAXPROCS"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When Golang program started in a container, the P (from Golang GMP model) will be set to the number of CPU cores of host instead of container's CPU limit (cgroups).

Assuming vault-agent sidecar is deployed on a 16core64g machine, the P of vault-agent will be set to the number of CPU cores by default, which is 16, and the available CPU of the vault-agent is 500m ([helm chart default setting](https://github.com/hashicorp/vault-helm/blob/main/values.yaml#L67)), which will cause the CPU to be used too high constantly. Solved by explicitly setting `GOMAXPROCS` to 1.

Therefore, add annotation `vault.hashicorp.com/go-max-procs` to support configuring P's number accordingly.

- P = 16

![perf-vault-agent](https://user-images.githubusercontent.com/12949466/162383203-dc78feaa-8d09-4fc6-bea8-e0d22547d09c.svg)

![image](https://user-images.githubusercontent.com/12949466/162382790-5ec843e1-e814-4577-bace-6b0a85f2259b.png)

- P = 1

![image](https://user-images.githubusercontent.com/12949466/162382942-661ed436-c33a-4f3f-8f50-d5c678f8e1a8.png)
