### PR TITLE
add share-process-namespace annotation

### DIFF
--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -93,6 +93,7 @@ func TestInitDefaults(t *testing.T) {
 		{annotationKey: AnnotationAgentImage, annotationValue: DefaultVaultImage},
 		{annotationKey: AnnotationAgentRunAsUser, annotationValue: strconv.Itoa(DefaultAgentRunAsUser)},
 		{annotationKey: AnnotationAgentRunAsGroup, annotationValue: strconv.Itoa(DefaultAgentRunAsGroup)},
+		{annotationKey: AnnotationAgentShareProcessNamespace, annotationValue: strconv.FormatBool(DefaultAgentShareProcessNamespace)},
 	}
 
 	for _, tt := range tests {
@@ -716,6 +717,14 @@ func TestCouldErrorAnnotations(t *testing.T) {
 		{AnnotationAgentRunAsGroup, "100", true},
 		{AnnotationAgentRunAsGroup, "root", false},
 
+		{AnnotationAgentShareProcessNamespace, "true", true},
+		{AnnotationAgentShareProcessNamespace, "false", true},
+		{AnnotationAgentShareProcessNamespace, "TRUE", true},
+		{AnnotationAgentShareProcessNamespace, "FALSE", true},
+		{AnnotationAgentShareProcessNamespace, "tRuE", false},
+		{AnnotationAgentShareProcessNamespace, "fAlSe", false},
+		{AnnotationAgentShareProcessNamespace, "", false},
+
 		{AnnotationAgentSetSecurityContext, "true", true},
 		{AnnotationAgentSetSecurityContext, "false", true},
 		{AnnotationAgentSetSecurityContext, "secure", false},
@@ -975,6 +984,7 @@ func TestInjectContainers(t *testing.T) {
 				{Operation: "add", Path: "/spec/containers/1/volumeMounts/-"},
 				{Operation: "add", Path: "/spec/containers/2/volumeMounts/-"},
 				{Operation: "add", Path: "/spec/initContainers"},
+				{Operation: "add", Path: "/spec/shareProcessNamespace"},
 				{Operation: "add", Path: "/spec/containers/-"},
 				{Operation: "add", Path: "/metadata/annotations/" + EscapeJSONPointer(AnnotationAgentStatus)},
 			},
@@ -989,6 +999,7 @@ func TestInjectContainers(t *testing.T) {
 				{Operation: "add", Path: "/spec/volumes"},
 				{Operation: "add", Path: "/spec/containers/1/volumeMounts/-"},
 				{Operation: "add", Path: "/spec/initContainers"},
+				{Operation: "add", Path: "/spec/shareProcessNamespace"},
 				{Operation: "add", Path: "/spec/containers/-"},
 				{Operation: "add", Path: "/metadata/annotations/" + EscapeJSONPointer(AnnotationAgentStatus)},
 			},
@@ -1004,6 +1015,7 @@ func TestInjectContainers(t *testing.T) {
 				{Operation: "add", Path: "/spec/containers/1/volumeMounts/-"},
 				{Operation: "add", Path: "/spec/containers/2/volumeMounts/-"},
 				{Operation: "add", Path: "/spec/initContainers"},
+				{Operation: "add", Path: "/spec/shareProcessNamespace"},
 				{Operation: "add", Path: "/spec/containers/-"},
 				{Operation: "add", Path: "/metadata/annotations/" + EscapeJSONPointer(AnnotationAgentStatus)},
 			},

--- a/agent-inject/agent/patch.go
+++ b/agent-inject/agent/patch.go
@@ -111,6 +111,17 @@ func updateAnnotations(target, annotations map[string]string) []*jsonpatch.JsonP
 	return result
 }
 
+func updateShareProcessNamespace(shareProcessNamespace bool) []*jsonpatch.JsonPatchOperation {
+	var result []*jsonpatch.JsonPatchOperation
+	result = append(result, &jsonpatch.JsonPatchOperation{
+		Operation: "add",
+		Path:      "/spec/shareProcessNamespace",
+		Value:     shareProcessNamespace,
+	})
+
+	return result
+}
+
 // EscapeJSONPointer escapes a JSON string to be compliant with the
 // JavaScript Object Notation (JSON) Pointer syntax RFC:
 // https://tools.ietf.org/html/rfc6901.

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -56,6 +56,7 @@ type Handler struct {
 	UserID                     string
 	GroupID                    string
 	SameID                     bool
+	ShareProcessNamespace      bool
 	SetSecurityContext         bool
 	DefaultTemplate            string
 	ResourceRequestCPU         string
@@ -187,6 +188,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		GroupID:                    h.GroupID,
 		SameID:                     h.SameID,
 		SetSecurityContext:         h.SetSecurityContext,
+		ShareProcessNamespace:      h.ShareProcessNamespace,
 		DefaultTemplate:            h.DefaultTemplate,
 		ResourceRequestCPU:         h.ResourceRequestCPU,
 		ResourceRequestMem:         h.ResourceRequestMem,

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -176,6 +176,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -237,6 +241,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -290,6 +298,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers/0/volumeMounts/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
 				},
 				{
 					Operation: "add",
@@ -354,6 +366,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -408,6 +424,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers/0/volumeMounts/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
 				},
 				{
 					Operation: "add",
@@ -511,6 +531,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
+				},
+				{
+					Operation: "add",
 					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
 				},
 			},
@@ -557,6 +581,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers/0/volumeMounts/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/shareProcessNamespace",
 				},
 				{
 					Operation: "add",


### PR DESCRIPTION
Many Helm Charts do not include an option to add the `shareProcessNamespace` switch to deployments.

Sharing the process namespace is needed to restart the pod on secret rotation as discussed in https://github.com/hashicorp/vault-k8s/issues/196.

This PR will enable adding the switch through annotations using the mutating webhook as discussed in https://github.com/kubernetes-sigs/external-dns/pull/2715.