### PR TITLE
VAULT-2230 Only update webhooks CA bundle when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Features:
 * Add agent-enable-quit annotation [GH-330](https://github.com/hashicorp/vault-k8s/pull/330)
 * Add go-max-procs annotation [GH-333](https://github.com/hashicorp/vault-k8s/pull/333)
 
+Changes:
+* Only update webhook CA bundles when needed [GH-336](https://github.com/hashicorp/vault-k8s/pull/336)
+
 ## 0.15.0 (March 21, 2022)
 
 Features:

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -368,7 +368,7 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.Bundle, client
 					err))
 				continue
 			}
-			if len(currentBundles) > 0 && bytes.Equal(currentBundles[0], bundle.CACert) {
+			if len(currentBundles) == 0 || !bytes.Equal(currentBundles[0], bundle.CACert) {
 				err = c.updateCABundle(ctx, &bundle, clientset, adminAPIVersion)
 				if err != nil {
 					c.UI.Error(fmt.Sprintf(


### PR DESCRIPTION
Instead of every second. Specifically, we now only update the webhooks
bundle if:

* we have generated a certificate and the CA bundle does not match the
  current webhook CA bundle; this will also happen if a new leader is
  elected, or
* the webhook itself was changed (e.g., by a helm upgrade), checked by
  `Watch`ing the webhooks.

In any case, will only send the `Patch` if the CA bundle on the
webhook no longer matches our own CA bundle.

This was tested by performing a `helm upgrade` with a webhook change and
verifying that the webhook change was noticed and the CA bundle was
patched, and also by setting the certificate lifetimes very low and
making sure that the CA bundle was *not* patched (since the CA did not
change when the certificate was regenerated).

Fixes #332.