### PR TITLE
Support min/max backoff annotations and env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 * Add agent-enable-quit annotation [GH-330](https://github.com/hashicorp/vault-k8s/pull/330)
 * Add go-max-procs annotation [GH-333](https://github.com/hashicorp/vault-k8s/pull/333)
+* Add min and max auth backoff annotations and environment variables [GH-341](https://github.com/hashicorp/vault-k8s/pull/341)
 
 Changes:
 * Only update webhook CA bundles when needed [GH-336](https://github.com/hashicorp/vault-k8s/pull/336)

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -269,6 +269,12 @@ type Vault struct {
 	// TLSServerName is the name of the Vault server to use when validating Vault's
 	// TLS certificates.
 	TLSServerName string
+
+	// AuthMinBackoff is the minimum time to backoff if auto auth fails.
+	AuthMinBackoff string
+
+	// AuthMinBackoff is the maximum time to backoff if auto auth fails.
+	AuthMaxBackoff string
 }
 
 type VaultAgentCache struct {
@@ -347,6 +353,8 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 			Role:             pod.Annotations[AnnotationVaultRole],
 			TLSSecret:        pod.Annotations[AnnotationVaultTLSSecret],
 			TLSServerName:    pod.Annotations[AnnotationVaultTLSServerName],
+			AuthMinBackoff:   pod.Annotations[AnnotationAgentAuthMinBackoff],
+			AuthMaxBackoff:   pod.Annotations[AnnotationAgentAuthMaxBackoff],
 		},
 	}
 

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -52,6 +52,8 @@ type Method struct {
 	MountPath  string                 `json:"mount_path,omitempty"`
 	WrapTTLRaw interface{}            `json:"wrap_ttl,omitempty"`
 	WrapTTL    time.Duration          `json:"-"`
+	MinBackoff string                 `json:"min_backoff,omitempty"`
+	MaxBackoff string                 `json:"max_backoff,omitempty"`
 	Namespace  string                 `json:"namespace,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
 }
@@ -167,10 +169,12 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 		},
 		AutoAuth: &AutoAuth{
 			Method: &Method{
-				Type:      a.Vault.AuthType,
-				Namespace: a.Vault.Namespace,
-				MountPath: a.Vault.AuthPath,
-				Config:    a.Vault.AuthConfig,
+				Type:       a.Vault.AuthType,
+				Namespace:  a.Vault.Namespace,
+				MountPath:  a.Vault.AuthPath,
+				Config:     a.Vault.AuthConfig,
+				MinBackoff: a.Vault.AuthMinBackoff,
+				MaxBackoff: a.Vault.AuthMaxBackoff,
 			},
 			Sinks: []*Sink{
 				{

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -64,6 +64,8 @@ type Handler struct {
 	ResourceLimitMem           string
 	ExitOnRetryFailure         bool
 	StaticSecretRenderInterval string
+	AuthMinBackoff             string
+	AuthMaxBackoff             string
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -194,6 +196,8 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		ResourceLimitMem:           h.ResourceLimitMem,
 		ExitOnRetryFailure:         h.ExitOnRetryFailure,
 		StaticSecretRenderInterval: h.StaticSecretRenderInterval,
+		AuthMinBackoff:             h.AuthMinBackoff,
+		AuthMaxBackoff:             h.AuthMaxBackoff,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -67,6 +67,8 @@ type Command struct {
 	flagResourceLimitMem           string // Set Memory limit in the injected containers
 	flagTLSMinVersion              string // Minimum TLS version supported by the webhook server
 	flagTLSCipherSuites            string // Comma-separated list of supported cipher suites
+	flagAuthMinBackoff             string // Auth min backoff on failure
+	flagAuthMaxBackoff             string // Auth min backoff on failure
 
 	flagSet *flag.FlagSet
 
@@ -199,6 +201,8 @@ func (c *Command) Run(args []string) int {
 		ResourceLimitMem:           c.flagResourceLimitMem,
 		ExitOnRetryFailure:         c.flagExitOnRetryFailure,
 		StaticSecretRenderInterval: c.flagStaticSecretRenderInterval,
+		AuthMinBackoff:             c.flagAuthMinBackoff,
+		AuthMaxBackoff:             c.flagAuthMaxBackoff,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -133,6 +133,8 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_TEMPLATE_STATIC_SECRET_RENDER_INTERVAL", value: "12s", cmdPtr: &cmd.flagStaticSecretRenderInterval},
 		{env: "AGENT_INJECT_TLS_MIN_VERSION", value: "tls13", cmdPtr: &cmd.flagTLSMinVersion},
 		{env: "AGENT_INJECT_TLS_CIPHER_SUITES", value: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", cmdPtr: &cmd.flagTLSCipherSuites},
+		{env: "AGENT_INJECT_AUTH_MIN_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMinBackoff},
+		{env: "AGENT_INJECT_AUTH_MAX_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMaxBackoff},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When auto auth fails, the agent will automatically retry with an
exponential backoff starting from 1 second up to 5 minutes. Those values
can be overridden in Vault itself. Here, we wire up agent to pass min
and max backoff values from its environment variables or the pod's
annotations.

* If the `AGENT_INJECT_AUTH_MIN_BACKOFF` or `AGENT_INJECT_MAX_BACKOFF`
  environment variables are set on the agent, these will be used as the
  default values.
* If a pod has the annotations `vault.hashicorp.com/auth-min-backoff` or
  `vault.hashicorp.com/auth-max-backoff` set, these will be used as the
  min and max backoff values. These will override any defaults from the
  agent environment variables.

The environment variables can be set via helm as well via, for example,

```sh
helm install vault hashicorp/vault \
  --set "injector.extraEnvironmentVars.AGENT_INJECT_AUTH_MIN_BACKOFF=4s" \
  --set "injector.extraEnvironmentVars.AGENT_INJECT_AUTH_MAX_BACKOFF=5s"
```

This was tested via `helm` and by setting the pod annotations and
confirming that the Vault agent picked up the settings when auto auth
is failing.