### PR TITLE
Stopped timer can cause certificate to never update

### DIFF
--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -355,7 +355,11 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.Bundle, client
 
 		// clear the timer
 		if !timer.Stop() {
-			<-timer.C
+			// non-blocking drain
+			select {
+			case <-timer.C:
+			default:
+			}
 		}
 
 		err := c.updateCertificate(ctx, clientset, bundle, webhooksCache, leaderElector, log)


### PR DESCRIPTION
Once the `time.NewTimer()` expires, calls to `timer.Stop()` will return
`false`, but the channel will have nothing in it, causing `<-timer.C` to
hang forever.

This is hinted at by the docs, even though they suggest `timer.Stop()`
should return true in that case.

We change to a non-blocking drain so that we won't block forever.

This manifests in never updating the certificate after it expires,
causing TLS handshake errors.

Fixes #275 