### PR TITLE
ConfigMap with missing vault section should default to env vars

### DIFF
--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/base64"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -64,6 +65,48 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 			Name:  "VAULT_CONFIG",
 			Value: b64Config,
 		})
+	} else {
+		// set up environment variables to access Vault since "vault" section may not be present in the config
+		if a.Vault.Address != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_ADDR",
+				Value: a.Vault.Address,
+			})
+		}
+		if a.Vault.CACert != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_CACERT",
+				Value: a.Vault.CACert,
+			})
+		}
+		if a.Vault.CAKey != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_CAPATH",
+				Value: a.Vault.CAKey,
+			})
+		}
+		if a.Vault.ClientCert != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_CLIENT_CERT",
+				Value: a.Vault.ClientCert,
+			})
+		}
+		if a.Vault.ClientKey != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_CLIENT_KEY",
+				Value: a.Vault.ClientKey,
+			})
+		}
+		envs = append(envs, corev1.EnvVar{
+			Name:  "VAULT_SKIP_VERIFY",
+			Value: strconv.FormatBool(a.Vault.TLSSkipVerify),
+		})
+		if a.Vault.TLSServerName != "" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "VAULT_TLS_SERVER_NAME",
+				Value: a.Vault.TLSServerName,
+			})
+		}
 	}
 
 	// Add IRSA AWS Env variables for vault containers

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -15,11 +15,11 @@ func TestContainerEnvs(t *testing.T) {
 		expectedEnvs []string
 	}{
 		{Agent{}, []string{"VAULT_CONFIG"}},
-		{Agent{ConfigMapName: "foobar"}, []string{}},
+		{Agent{Vault: Vault{Address: "http://localhost:8200"}, ConfigMapName: "foobar"}, []string{"VAULT_SKIP_VERIFY", "VAULT_ADDR"}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
 		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
 		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{Address: "http://localhost:8200", ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY", "VAULT_SKIP_VERIFY", "VAULT_ADDR"}},
 		{Agent{Vault: Vault{GoMaxProcs: "1"}}, []string{"VAULT_CONFIG", "GOMAXPROCS"}},
 	}
 

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -446,7 +446,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 2
+	expectedEnvs := 9
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}


### PR DESCRIPTION
When using a ConfigMap to hold the agent config, it is natural to omit
the `vault` section, since the config may be hard-coded and won't know
necessarily know the correct address for the Vault server.

In that case, we should set any known information about the Vault server
(address, cert, etc.) in environment variables passed to the agent so
that it can connect to the correct Vault server.

Fixes #300