### PR TITLE
Wait for certificate before starting HTTP listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Unreleased
 
+Improvements:
+* ConfigMap with missing vault section should default to env vars [GH-353](https://github.com/hashicorp/vault-k8s/pull/353)
+
 Changes:
 * Certificate watcher timer deadlock fix [GH-350]([https://github.com/hashicorp/vault-k8s/pull/350)
+* Wait for certificate before starting HTTP listener [GH-354](https://github.com/hashicorp/vault-k8s/pull/354)
+* Update example injector mutating webhook config to exclude agent pod [GH-351](https://github.com/hashicorp/vault-k8s/pull/351)
 
 ## 0.16.0 (May 11, 2022)
 


### PR DESCRIPTION
When starting up, the HTTP server can start accepting requests before
the TLS config has loaded certificates from the certificate generator.

We add in a wait (assuming we don't have certificates already given to
us via flags or environment variables) for that certificate to be
generated before starting the server to prevent confusing, though
harmless, errors in logs.

* Fixes #318
* Fixes #320