### PR TITLE
Specify Docker linux/amd64 platform for UBI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ image: build
 	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
 
 prod-ubi-image:
-	docker build -t $(IMAGE_TAG)_ubi \
+	docker build --platform linux/amd64 -t $(IMAGE_TAG)_ubi \
     --build-arg VERSION=$(VERSION) \
     --build-arg LOCATION=$(PUBLISH_LOCATION) \
     -f $(DOCKER_DIR)/Release.ubi.dockerfile .


### PR DESCRIPTION
As many of us are moving to ARM laptops, it helps to specify the
platform for Docker.

We only support amd64 currently for UBI.