### PR TITLE
Set request UID when returning admission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* Properly return admission errors [GH-363](https://github.com/hashicorp/vault-k8s/pull/363)
+
 ## 0.16.1 (May 25, 2022)
 
 Improvements:

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 )
@@ -148,6 +149,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		h.Log.Error("could not unmarshal request to pod: %s", err)
 		h.Log.Debug("%s", req.Object.Raw)
 		return &admissionv1.AdmissionResponse{
+			UID: req.UID,
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -164,7 +166,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	inject, err := agent.ShouldInject(&pod)
 	if err != nil && !strings.Contains(err.Error(), "no inject annotation found") {
 		err := fmt.Errorf("error checking if should inject agent: %s", err)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	} else if !inject {
 		return resp
 	}
@@ -172,7 +174,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	h.Log.Debug("checking namespaces..")
 	if strutil.StrListContains(kubeSystemNamespaces, req.Namespace) {
 		err := fmt.Errorf("error with request namespace: cannot inject into system namespaces: %s", req.Namespace)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	}
 
 	h.Log.Debug("setting default annotations..")
@@ -202,28 +204,28 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	err = agent.Init(&pod, cfg)
 	if err != nil {
 		err := fmt.Errorf("error adding default annotations: %s", err)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	}
 
 	h.Log.Debug("creating new agent..")
 	agentSidecar, err := agent.New(&pod, patches)
 	if err != nil {
 		err := fmt.Errorf("error creating new agent sidecar: %s", err)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	}
 
 	h.Log.Debug("validating agent configuration..")
 	err = agentSidecar.Validate()
 	if err != nil {
 		err := fmt.Errorf("error validating agent configuration: %s", err)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	}
 
 	h.Log.Debug("creating patches for the pod..")
 	patch, err := agentSidecar.Patch()
 	if err != nil {
 		err := fmt.Errorf("error creating patch for agent: %s", err)
-		return admissionError(err)
+		return admissionError(req.UID, err)
 	}
 
 	resp.Patch = patch
@@ -233,8 +235,9 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	return resp
 }
 
-func admissionError(err error) *admissionv1.AdmissionResponse {
+func admissionError(UID types.UID, err error) *admissionv1.AdmissionResponse {
 	return &admissionv1.AdmissionResponse{
+		UID: UID,
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},


### PR DESCRIPTION
Otherwise the error returned from vault-k8s will not show up in the events of the object that owns the Pod (ex. a ReplicaSet). I suspect the UID started being required with v1 of the admission API.

Currently without this patch, kube-apiserver logs something like this when vault-k8s returns an AdmissionError:

```
E0616 23:21:07.674311       1 dispatcher.go:184] failed calling webhook "vault.hashicorp.com": received invalid webhook response: expected response.uid="3d19f57a-2a0e-4bc9-8a0e-d54c413b21e5", got ""
```