### PR TITLE
Support disable_idle_connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* Support for setting [`disable_idle_connections`](https://github.com/hashicorp/vault/pull/15986) in the agent config [GH-366](https://github.com/hashicorp/vault-k8s/pull/366)
+
 Improvements:
 * Added support to configure default vault namespace on the agent config [GH-345](https://github.com/hashicorp/vault-k8s/pull/345)
 

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -163,6 +163,10 @@ type Agent struct {
 	// EnableQuit controls whether the quit endpoint is enabled on a localhost
 	// listener
 	EnableQuit bool
+
+	// DisableIdleConnections controls which Agent features have idle
+	// connections disabled
+	DisableIdleConnections []string
 }
 
 type ServiceAccountTokenVolume struct {
@@ -461,6 +465,10 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 	agent.EnableQuit, err = agent.getEnableQuit()
 	if err != nil {
 		return nil, err
+	}
+
+	if pod.Annotations[AnnotationAgentDisableIdleConnections] != "" {
+		agent.DisableIdleConnections = strings.Split(pod.Annotations[AnnotationAgentDisableIdleConnections], ",")
 	}
 
 	return agent, nil

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -271,6 +271,11 @@ const (
 	// AnnotationAgentAuthMaxBackoff specifies the maximum backoff duration used when the agent auto auth fails.
 	// Defaults to 5 minutes.
 	AnnotationAgentAuthMaxBackoff = "vault.hashicorp.com/auth-max-backoff"
+
+	// AnnotationAgentDisableIdleConnections specifies disabling idle connections for various
+	// features in Vault Agent. Comma-separated string, with valid values auto-auth, caching,
+	// templating.
+	AnnotationAgentDisableIdleConnections = "vault.hashicorp.com/agent-disable-idle-connections"
 )
 
 type AgentConfig struct {
@@ -295,6 +300,7 @@ type AgentConfig struct {
 	StaticSecretRenderInterval string
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
+	DisableIdleConnections     string
 }
 
 // Init configures the expected annotations required to create a new instance
@@ -489,6 +495,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 	} else if cfg.AuthMaxBackoff != "" {
 		// set default from env/flag
 		pod.ObjectMeta.Annotations[AnnotationAgentAuthMaxBackoff] = cfg.AuthMaxBackoff
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentDisableIdleConnections]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentDisableIdleConnections] = cfg.DisableIdleConnections
 	}
 
 	return nil

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -19,14 +19,15 @@ const (
 // Config is the top level struct that composes a Vault Agent
 // configuration file.
 type Config struct {
-	AutoAuth       *AutoAuth       `json:"auto_auth"`
-	ExitAfterAuth  bool            `json:"exit_after_auth"`
-	PidFile        string          `json:"pid_file"`
-	Vault          *VaultConfig    `json:"vault"`
-	Templates      []*Template     `json:"template,omitempty"`
-	Listener       []*Listener     `json:"listener,omitempty"`
-	Cache          *Cache          `json:"cache,omitempty"`
-	TemplateConfig *TemplateConfig `json:"template_config,omitempty"`
+	AutoAuth               *AutoAuth       `json:"auto_auth"`
+	ExitAfterAuth          bool            `json:"exit_after_auth"`
+	PidFile                string          `json:"pid_file"`
+	Vault                  *VaultConfig    `json:"vault"`
+	Templates              []*Template     `json:"template,omitempty"`
+	Listener               []*Listener     `json:"listener,omitempty"`
+	Cache                  *Cache          `json:"cache,omitempty"`
+	TemplateConfig         *TemplateConfig `json:"template_config,omitempty"`
+	DisableIdleConnections []string        `json:"disable_idle_connections,omitempty"`
 }
 
 // Vault contains configuration for connecting to Vault servers
@@ -190,6 +191,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 			ExitOnRetryFailure:         a.VaultAgentTemplateConfig.ExitOnRetryFailure,
 			StaticSecretRenderInterval: a.VaultAgentTemplateConfig.StaticSecretRenderInterval,
 		},
+		DisableIdleConnections: a.DisableIdleConnections,
 	}
 
 	if a.InjectToken {

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -68,6 +68,7 @@ type Handler struct {
 	StaticSecretRenderInterval string
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
+	DisableIdleConnections     string
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -202,6 +203,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		StaticSecretRenderInterval: h.StaticSecretRenderInterval,
 		AuthMinBackoff:             h.AuthMinBackoff,
 		AuthMaxBackoff:             h.AuthMaxBackoff,
+		DisableIdleConnections:     h.DisableIdleConnections,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/informers"
 	informerv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/listers/admissionregistration/v1"
+	v1 "k8s.io/client-go/listers/admissionregistration/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -71,6 +71,7 @@ type Command struct {
 	flagTLSCipherSuites            string // Comma-separated list of supported cipher suites
 	flagAuthMinBackoff             string // Auth min backoff on failure
 	flagAuthMaxBackoff             string // Auth min backoff on failure
+	flagDisableIdleConnections     string // Idle connections control
 
 	flagSet *flag.FlagSet
 
@@ -207,6 +208,7 @@ func (c *Command) Run(args []string) int {
 		StaticSecretRenderInterval: c.flagStaticSecretRenderInterval,
 		AuthMinBackoff:             c.flagAuthMinBackoff,
 		AuthMaxBackoff:             c.flagAuthMaxBackoff,
+		DisableIdleConnections:     c.flagDisableIdleConnections,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -119,6 +119,9 @@ type Specification struct {
 
 	// AuthMaxBackoff is the AGENT_MAX_BACKOFF environment variable
 	AuthMaxBackoff string `envconfig:"AGENT_INJECT_AUTH_MAX_BACKOFF"`
+
+	// DisableIdleConnections is the AGENT_INJECT_DISABLE_IDLE_CONNECTIONS environment variable
+	DisableIdleConnections string `split_words:"true"`
 }
 
 func (c *Command) init() {
@@ -183,6 +186,8 @@ func (c *Command) init() {
 		"Sets the minimum backoff on auto-auth failure. Default is 1s")
 	c.flagSet.StringVar(&c.flagAuthMaxBackoff, "auth-max-backoff", "",
 		"Sets the maximum backoff on auto-auth failure. Default is 5m")
+	c.flagSet.StringVar(&c.flagDisableIdleConnections, "disable-idle-connections", "",
+		"Comma-separated list of Vault features where idle connections should be disabled.")
 
 	tlsVersions := []string{}
 	for v := range tlsutil.TLSLookup {
@@ -378,6 +383,10 @@ func (c *Command) parseEnvs() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if envs.DisableIdleConnections != "" {
+		c.flagDisableIdleConnections = envs.DisableIdleConnections
 	}
 
 	return nil

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -136,6 +136,7 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_TLS_CIPHER_SUITES", value: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", cmdPtr: &cmd.flagTLSCipherSuites},
 		{env: "AGENT_INJECT_AUTH_MIN_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMinBackoff},
 		{env: "AGENT_INJECT_AUTH_MAX_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMaxBackoff},
+		{env: "AGENT_INJECT_DISABLE_IDLE_CONNECTIONS", value: "auto-auth,caching,templating", cmdPtr: &cmd.flagDisableIdleConnections},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds support for setting [`disable_idle_connections`](https://github.com/hashicorp/vault/pull/15986) in the injected
agent's config, via an annotation per-pod (`vault.hashicorp.com/agent-disable-idle-connections`), or the `AGENT_INJECT_DISABLE_IDLE_CONNECTIONS` environment variable that will affect all injections.

annotation:
```yaml
metadata:
  annotations:
    vault.hashicorp.com/agent-disable-idle-connections: "auto-auth,caching,templating"
```

environment variable with helm cli:
```sh
helm install vault hashicorp/vault \
  --set injector.extraEnvironmentVars.AGENT_INJECT_DISABLE_IDLE_CONNECTIONS="auto-auth\,caching\,templating"
```

environment variable with helm values file:
```yaml
# values.yaml
injector:
  extraEnvironmentVars:
    AGENT_INJECT_DISABLE_IDLE_CONNECTIONS: "auto-auth,caching,templating"
```
