### PR TITLE
Run acceptance tests from vault-helm repo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,11 +18,11 @@ jobs:
           echo "::set-output name=go-version::$(cat .go-version)"
 
   test:
+    env:
+      TARBALL_FILE: vault-k8s-image.docker.tar
     needs:
       - get-go-version
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
     steps:
       - uses: actions/checkout@v2
 
@@ -41,10 +41,17 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: Build
-        run: make build
+        run: |
+          REGISTRY=hashicorp make build image
+          docker save --output "${TARBALL_FILE}" hashicorp/vault-k8s:0.0.0-dev
 
       - name: Test
         run: make test
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vault-k8s-image
+          path: ${{ env.TARBALL_FILE }}
 
   acceptance:
     needs:
@@ -69,32 +76,6 @@ jobs:
       - run: pip install yq
         shell: bash
 
-      # Checkout vault-k8s to build tip.
-      - uses: actions/checkout@v2
-        with:
-          path: "vault-k8s"
-
-      - name: Create K8s Kind Cluster
-        uses: helm/kind-action@v1.2.0
-        with:
-          cluster_name: kind
-          config: vault-k8s/test/kind/config.yaml
-          node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.14.0
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - run: |
-          REGISTRY=hashicorp make -C vault-k8s image
-          kind load docker-image hashicorp/vault-k8s:0.0.0-dev
-
       # Checkout vault-helm for acceptance test code.
       - uses: actions/checkout@v2
         with:
@@ -102,6 +83,24 @@ jobs:
           ref: "v0.20.1"
           path: "vault-helm"
 
-      - run: |
+      - name: Create K8s Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: kind
+          config: vault-helm/test/kind/config.yaml
+          node_image: kindest/node:v${{ matrix.kind-k8s-version }}
+          version: v0.14.0
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: vault-k8s-image
+
+      - name: Load vault-k8s dev image
+        run: |
+          docker image load --input vault-k8s-image.docker.tar
+          kind load docker-image hashicorp/vault-k8s:0.0.0-dev
+
+      - name: bats tests
+        run: |
           yq --in-place --yaml-roundtrip '.injector.image.tag |= "0.0.0-dev"' ./vault-helm/values.yaml
-          CLEANUP=false bats ./vault-helm/test/acceptance -t --filter injector
+          bats ./vault-helm/test/acceptance -t --filter injector

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "::set-output name=go-version::$(cat .go-version)"
 
-  build:
+  test:
     needs:
       - get-go-version
     runs-on: ubuntu-latest
@@ -45,3 +45,63 @@ jobs:
 
       - name: Test
         run: make test
+
+  acceptance:
+    needs:
+      - test
+    strategy:
+      fail-fast: false
+      matrix:
+        kind-k8s-version: [1.19.16, 1.20.15, 1.21.12, 1.22.9, 1.23.6, 1.24.2]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup test tools from https://github.com/hashicorp/vault-helm/blob/main/.github/workflows/setup-test-tools/action.yaml
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install -g bats@${BATS_VERSION}
+        shell: bash
+        env:
+          BATS_VERSION: '1.5.0'
+      - run: bats -v
+        shell: bash
+      - uses: actions/setup-python@v2
+      - run: pip install yq
+        shell: bash
+
+      # Checkout vault-k8s to build tip.
+      - uses: actions/checkout@v2
+        with:
+          path: "vault-k8s"
+
+      - name: Create K8s Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: kind
+          config: vault-k8s/test/kind/config.yaml
+          node_image: kindest/node:v${{ matrix.kind-k8s-version }}
+          version: v0.14.0
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - run: |
+          REGISTRY=hashicorp make -C vault-k8s image
+          kind load docker-image hashicorp/vault-k8s:0.0.0-dev
+
+      # Checkout vault-helm for acceptance test code.
+      - uses: actions/checkout@v2
+        with:
+          repository: "hashicorp/vault-helm"
+          ref: "v0.20.1"
+          path: "vault-helm"
+
+      - run: |
+          yq --in-place --yaml-roundtrip '.injector.image.tag |= "0.0.0-dev"' ./vault-helm/values.yaml
+          CLEANUP=false bats ./vault-helm/test/acceptance -t --filter injector

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,7 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-- role: worker
-- role: worker
-- role: worker


### PR DESCRIPTION
Run the acceptance tests from the vault-helm repo using a matrix testing strategy to ensure basic compatibility with all recent Kubernetes minor versions.

I wanted to try to re-use the helm tests instead of having to maintain an additional set of complex acceptance tests, but lmk if you think this repo should have its own test suite instead. It could also be that we just use the helm tests as a base set and add more bats tests within this repo in the future to cover injector specific things like mutating web hook API versions.