### PR TITLE
Support disable_keep_alives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* Support for setting [`disable_keep_alives`](https://github.com/hashicorp/vault/pull/16479) in the agent config [GH-376](https://github.com/hashicorp/vault-k8s/pull/376)
+
 ## 0.17.0 (July 28, 2022)
 
 Features:

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -168,7 +168,7 @@ type Agent struct {
 	// connections disabled
 	DisableIdleConnections []string
 
-	// DisableKeepAlives controls which Agent features have keep-alives disables.
+	// DisableKeepAlives controls which Agent features have keep-alives disabled.
 	DisableKeepAlives []string
 }
 

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -167,6 +167,9 @@ type Agent struct {
 	// DisableIdleConnections controls which Agent features have idle
 	// connections disabled
 	DisableIdleConnections []string
+
+	// DisableKeepAlives controls which Agent features have keep-alives disables.
+	DisableKeepAlives []string
 }
 
 type ServiceAccountTokenVolume struct {
@@ -469,6 +472,10 @@ func New(pod *corev1.Pod, patches []*jsonpatch.JsonPatchOperation) (*Agent, erro
 
 	if pod.Annotations[AnnotationAgentDisableIdleConnections] != "" {
 		agent.DisableIdleConnections = strings.Split(pod.Annotations[AnnotationAgentDisableIdleConnections], ",")
+	}
+
+	if pod.Annotations[AnnotationAgentDisableKeepAlives] != "" {
+		agent.DisableKeepAlives = strings.Split(pod.Annotations[AnnotationAgentDisableKeepAlives], ",")
 	}
 
 	return agent, nil

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -276,6 +276,11 @@ const (
 	// features in Vault Agent. Comma-separated string, with valid values auto-auth, caching,
 	// templating.
 	AnnotationAgentDisableIdleConnections = "vault.hashicorp.com/agent-disable-idle-connections"
+
+	// AnnotationAgentDisableKeepAlives specifies disabling keep-alives for various
+	// features in Vault Agent. Comma-separated string, with valid values auto-auth, caching,
+	// templating.
+	AnnotationAgentDisableKeepAlives = "vault.hashicorp.com/agent-disable-keep-alives"
 )
 
 type AgentConfig struct {
@@ -301,6 +306,7 @@ type AgentConfig struct {
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
 	DisableIdleConnections     string
+	DisableKeepAlives          string
 }
 
 // Init configures the expected annotations required to create a new instance
@@ -499,6 +505,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentDisableIdleConnections]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentDisableIdleConnections] = cfg.DisableIdleConnections
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentDisableKeepAlives]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentDisableKeepAlives] = cfg.DisableKeepAlives
 	}
 
 	return nil

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -1189,3 +1189,39 @@ func TestDisableIdleConnections(t *testing.T) {
 		})
 	}
 }
+
+func TestDisableKeepAlives(t *testing.T) {
+	tests := map[string]struct {
+		annotations   map[string]string
+		expectedValue []string
+	}{
+		"full list": {
+			annotations: map[string]string{
+				"vault.hashicorp.com/agent-disable-keep-alives": "auto-auth,caching,templating",
+			},
+			expectedValue: []string{"auto-auth", "caching", "templating"},
+		},
+		"one": {
+			annotations: map[string]string{
+				"vault.hashicorp.com/agent-disable-keep-alives": "auto-auth",
+			},
+			expectedValue: []string{"auto-auth"},
+		},
+		"none": {
+			annotations:   map[string]string{},
+			expectedValue: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pod := testPod(tc.annotations)
+			agentConfig := basicAgentConfig()
+			err := Init(pod, agentConfig)
+			require.NoError(t, err)
+			agent, err := New(pod, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedValue, agent.DisableKeepAlives)
+		})
+	}
+}

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Cache                  *Cache          `json:"cache,omitempty"`
 	TemplateConfig         *TemplateConfig `json:"template_config,omitempty"`
 	DisableIdleConnections []string        `json:"disable_idle_connections,omitempty"`
+	DisableKeepAlives      []string        `json:"disable_keep_alives,omitempty"`
 }
 
 // Vault contains configuration for connecting to Vault servers
@@ -192,6 +193,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 			StaticSecretRenderInterval: a.VaultAgentTemplateConfig.StaticSecretRenderInterval,
 		},
 		DisableIdleConnections: a.DisableIdleConnections,
+		DisableKeepAlives:      a.DisableKeepAlives,
 	}
 
 	if a.InjectToken {

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -69,6 +69,7 @@ type Handler struct {
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
 	DisableIdleConnections     string
+	DisableKeepAlives          string
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
@@ -204,6 +205,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		AuthMinBackoff:             h.AuthMinBackoff,
 		AuthMaxBackoff:             h.AuthMaxBackoff,
 		DisableIdleConnections:     h.DisableIdleConnections,
+		DisableKeepAlives:          h.DisableKeepAlives,
 	}
 	err = agent.Init(&pod, cfg)
 	if err != nil {

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -72,6 +72,7 @@ type Command struct {
 	flagAuthMinBackoff             string // Auth min backoff on failure
 	flagAuthMaxBackoff             string // Auth min backoff on failure
 	flagDisableIdleConnections     string // Idle connections control
+	flagDisableKeepAlives          string // Keep-alives control
 
 	flagSet *flag.FlagSet
 
@@ -209,6 +210,7 @@ func (c *Command) Run(args []string) int {
 		AuthMinBackoff:             c.flagAuthMinBackoff,
 		AuthMaxBackoff:             c.flagAuthMaxBackoff,
 		DisableIdleConnections:     c.flagDisableIdleConnections,
+		DisableKeepAlives:          c.flagDisableKeepAlives,
 	}
 
 	mux := http.NewServeMux()

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -122,6 +122,9 @@ type Specification struct {
 
 	// DisableIdleConnections is the AGENT_INJECT_DISABLE_IDLE_CONNECTIONS environment variable
 	DisableIdleConnections string `split_words:"true"`
+
+	// DisableKeepAlives is the AGENT_INJECT_DISABLE_KEEP_ALIVES environment variable
+	DisableKeepAlives string `split_words:"true"`
 }
 
 func (c *Command) init() {
@@ -188,6 +191,8 @@ func (c *Command) init() {
 		"Sets the maximum backoff on auto-auth failure. Default is 5m")
 	c.flagSet.StringVar(&c.flagDisableIdleConnections, "disable-idle-connections", "",
 		"Comma-separated list of Vault features where idle connections should be disabled.")
+	c.flagSet.StringVar(&c.flagDisableKeepAlives, "disable-keep-alives", "",
+		"Comma-separated list of Vault features where keep-alives should be disabled.")
 
 	tlsVersions := []string{}
 	for v := range tlsutil.TLSLookup {
@@ -387,6 +392,10 @@ func (c *Command) parseEnvs() error {
 
 	if envs.DisableIdleConnections != "" {
 		c.flagDisableIdleConnections = envs.DisableIdleConnections
+	}
+
+	if envs.DisableKeepAlives != "" {
+		c.flagDisableKeepAlives = envs.DisableKeepAlives
 	}
 
 	return nil

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -137,6 +137,7 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_AUTH_MIN_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMinBackoff},
 		{env: "AGENT_INJECT_AUTH_MAX_BACKOFF", value: "5s", cmdPtr: &cmd.flagAuthMaxBackoff},
 		{env: "AGENT_INJECT_DISABLE_IDLE_CONNECTIONS", value: "auto-auth,caching,templating", cmdPtr: &cmd.flagDisableIdleConnections},
+		{env: "AGENT_INJECT_DISABLE_KEEP_ALIVES", value: "auto-auth,caching,templating", cmdPtr: &cmd.flagDisableKeepAlives},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Follow up for https://github.com/hashicorp/vault/pull/16479, which
added support for `disable_keep_alives`

This is used very similarly to `disable_idle_connections`, which was
added in https://github.com/hashicorp/vault-k8s/pull/366

This adds the `disable_keep_alives` setting into the injected agent's
config, which can be specified per pod:

```yaml
metadata:
  annotations:
    vault.hashicorp.com/agent-disable-keep-alives: "auto-auth,caching,templating"
```

globally in the injector through the helm command when deploying:

```sh
helm install vault hashicorp/vault \
  --set injector.extraEnvironmentVars.AGENT_INJECT_DISABLE_KEEP_ALIVES="auto-auth\,caching\,templating"
```

or through the helm `values.yaml` file:

```yaml
injector:
  extraEnvironmentVars:
    AGENT_INJECT_DISABLE_KEEP_ALIVES: "auto-auth,caching,templating"
```

This was copied almost verbatim from #366, so thanks @tvoran :)

Co-authored-by: Theron Voran <theron@hashicorp.com>