### PR TITLE
Pin Docker base alpine image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Changes:
+* Upgrade Docker base image to alpine:3.16.2 [GH-382](https://github.com/hashicorp/vault-k8s/pull/382)
+
 Features:
 * Support for setting [`disable_keep_alives`](https://github.com/hashicorp/vault/pull/16479) in the agent config [GH-376](https://github.com/hashicorp/vault-k8s/pull/376)
 * Added flags, envs and annotations to control ephemeral storage resources for injected containers: [GH-360](https://github.com/hashicorp/vault-k8s/pull/360)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.mirror.hashicorp.services/alpine:latest as dev
+ARG ALPINE_VERSION=3.16.2
+
+FROM docker.mirror.hashicorp.services/alpine:${ALPINE_VERSION} as dev
 
 RUN addgroup vault && \
     adduser -S -G vault vault
@@ -10,7 +12,7 @@ USER vault
 ENTRYPOINT ["/vault-k8s"]
 
 # This target creates a production release image for the project.
-FROM docker.mirror.hashicorp.services/alpine:latest as default
+FROM docker.mirror.hashicorp.services/alpine:${ALPINE_VERSION} as default
 
 # PRODUCT_VERSION is the tag built, e.g. v0.1.0
 # PRODUCT_REVISION is the git hash built


### PR DESCRIPTION
Our current 0.17.0 release is built on 3.16.1. 3.16.2 addresses the CVE reported in https://github.com/hashicorp/vault-helm/issues/774.