### PR TITLE
Switch to newer json-patch; remove dead code

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -518,7 +518,8 @@ func ShouldInject(pod *corev1.Pod) (bool, error) {
 
 // Patch creates the necessary pod patches to inject the Vault Agent
 // containers.
-func (a *Agent) Patch() (patches jsonpatch.Patch, patchesBytes []byte, err error) {
+func (a *Agent) Patch() ([]byte, error) {
+	var patches jsonpatch.Patch
 	// Add a volume for the token sink
 	patches = append(patches, addVolumes(
 		a.Pod.Spec.Volumes,
@@ -576,10 +577,9 @@ func (a *Agent) Patch() (patches jsonpatch.Patch, patchesBytes []byte, err error
 
 	// Init Container
 	if a.PrePopulate {
-		var container corev1.Container
-		container, err = a.ContainerInitSidecar()
+		container, err := a.ContainerInitSidecar()
 		if err != nil {
-			return
+			return nil, err
 		}
 
 		containers := a.Pod.Spec.InitContainers
@@ -623,10 +623,9 @@ func (a *Agent) Patch() (patches jsonpatch.Patch, patchesBytes []byte, err error
 
 	// Sidecar Container
 	if !a.PrePopulateOnly {
-		var container corev1.Container
-		container, err = a.ContainerSidecar()
+		container, err := a.ContainerSidecar()
 		if err != nil {
-			return
+			return nil, err
 		}
 		patches = append(patches, addContainers(
 			a.Pod.Spec.Containers,
@@ -641,9 +640,9 @@ func (a *Agent) Patch() (patches jsonpatch.Patch, patchesBytes []byte, err error
 
 	// Generate the patch
 	if len(patches) > 0 {
-		patchesBytes, err = json.Marshal(patches)
+		return json.Marshal(patches)
 	}
-	return
+	return nil, nil
 }
 
 // Validate the instance of Agent to ensure we have everything needed

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -1023,7 +1023,7 @@ func TestInjectContainers(t *testing.T) {
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}
-			_, patch, err := agent.Patch()
+			patch, err := agent.Patch()
 			if err != nil {
 				t.Errorf("got error, shouldn't have: %s", err)
 			}

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +44,6 @@ func TestNewConfig(t *testing.T) {
 	}
 
 	pod := testPod(annotations)
-	var patches []*jsonpatch.JsonPatchOperation
 
 	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
@@ -53,7 +51,7 @@ func TestNewConfig(t *testing.T) {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
 	}
 
-	agent, err := New(pod, patches)
+	agent, err := New(pod)
 	if err != nil {
 		t.Errorf("got error creating agent, shouldn't have: %s", err)
 	}
@@ -214,7 +212,6 @@ func TestFilePathAndName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
@@ -222,7 +219,7 @@ func TestFilePathAndName(t *testing.T) {
 				t.Errorf("got error initialising pod, shouldn't have: %s", err)
 			}
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			if err != nil {
 				t.Errorf("got error creating agent, shouldn't have: %s", err)
 			}
@@ -302,7 +299,6 @@ func TestFilePermission(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
@@ -310,7 +306,7 @@ func TestFilePermission(t *testing.T) {
 				t.Errorf("got error initialising pod, shouldn't have: %s", err)
 			}
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			if err != nil {
 				t.Errorf("got error creating agent, shouldn't have: %s", err)
 			}
@@ -334,7 +330,6 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 	annotations := map[string]string{}
 
 	pod := testPod(annotations)
-	var patches []*jsonpatch.JsonPatchOperation
 
 	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
@@ -342,7 +337,7 @@ func TestConfigVaultAgentCacheNotEnabledByDefault(t *testing.T) {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
 	}
 
-	agent, err := New(pod, patches)
+	agent, err := New(pod)
 	if err != nil {
 		t.Errorf("got error creating agent, shouldn't have: %s", err)
 	}
@@ -370,7 +365,6 @@ func TestConfigVaultAgentCache(t *testing.T) {
 	}
 
 	pod := testPod(annotations)
-	var patches []*jsonpatch.JsonPatchOperation
 
 	agentConfig := basicAgentConfig()
 	err := Init(pod, agentConfig)
@@ -378,7 +372,7 @@ func TestConfigVaultAgentCache(t *testing.T) {
 		t.Errorf("got error initialising pod, shouldn't have: %s", err)
 	}
 
-	agent, err := New(pod, patches)
+	agent, err := New(pod)
 	if err != nil {
 		t.Errorf("got error creating agent, shouldn't have: %s", err)
 	}
@@ -499,13 +493,12 @@ func TestConfigVaultAgentCache_persistent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			require.NoError(t, err, "got error initialising pod: %s", err)
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			require.NoError(t, err, "got error creating agent: %s", err)
 
 			initCfg, err := agent.newConfig(true)
@@ -573,13 +566,12 @@ func TestConfigVaultAgentTemplateConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			require.NoError(t, err)
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			require.NoError(t, err)
 			cfg, err := agent.newConfig(true)
 			require.NoError(t, err)
@@ -647,13 +639,12 @@ func TestInjectTokenSink(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			require.NoError(t, err)
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			require.NoError(t, err)
 			cfg, err := agent.newConfig(true)
 			require.NoError(t, err)
@@ -745,13 +736,12 @@ func TestConfigAgentQuit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := testPod(tt.annotations)
-			var patches []*jsonpatch.JsonPatchOperation
 
 			agentConfig := basicAgentConfig()
 			err := Init(pod, agentConfig)
 			require.NoError(t, err)
 
-			agent, err := New(pod, patches)
+			agent, err := New(pod)
 			require.NoError(t, err)
 			// create sidecar config
 			cfg, err := agent.newConfig(false)

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -1257,8 +1258,10 @@ func TestContainerCache(t *testing.T) {
 			sidecar, err := agent.ContainerSidecar()
 			require.NoError(t, err)
 
-			patches, _, err := agent.Patch()
+			patch, err := agent.Patch()
 			require.NoError(t, err)
+			var patches jsonpatch.Patch
+			require.NoError(t, json.Unmarshal(patch, &patches))
 
 			if tt.expectCacheVolAndMount {
 				assert.Subset(t, init.VolumeMounts, cacheMount)

--- a/agent-inject/agent/patch.go
+++ b/agent-inject/agent/patch.go
@@ -1,16 +1,15 @@
 package agent
 
 import (
-	"strings"
-
-	"github.com/mattbaird/jsonpatch"
+	"github.com/evanphx/json-patch"
+	"github.com/hashicorp/vault-k8s/agent-inject/internal"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // TODO this can be broken down into a common code and type switched.
 
-func addVolumes(target, volumes []corev1.Volume, base string) []*jsonpatch.JsonPatchOperation {
-	var result []*jsonpatch.JsonPatchOperation
+func addVolumes(target, volumes []corev1.Volume, base string) jsonpatch.Patch {
+	var result jsonpatch.Patch
 	first := len(target) == 0
 	var value interface{}
 	for _, v := range volumes {
@@ -23,17 +22,13 @@ func addVolumes(target, volumes []corev1.Volume, base string) []*jsonpatch.JsonP
 			path = path + "/-"
 		}
 
-		result = append(result, &jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      path,
-			Value:     value,
-		})
+		result = append(result, internal.AddOp(path, value))
 	}
 	return result
 }
 
-func addVolumeMounts(target, mounts []corev1.VolumeMount, base string) []*jsonpatch.JsonPatchOperation {
-	var result []*jsonpatch.JsonPatchOperation
+func addVolumeMounts(target, mounts []corev1.VolumeMount, base string) jsonpatch.Patch {
+	var result jsonpatch.Patch
 	first := len(target) == 0
 	var value interface{}
 	for _, v := range mounts {
@@ -46,26 +41,17 @@ func addVolumeMounts(target, mounts []corev1.VolumeMount, base string) []*jsonpa
 			path = path + "/-"
 		}
 
-		result = append(result, &jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      path,
-			Value:     value,
-		})
+		result = append(result, internal.AddOp(path, value))
 	}
 	return result
 }
 
-func removeContainers(path string) []*jsonpatch.JsonPatchOperation {
-	var result []*jsonpatch.JsonPatchOperation
-
-	return append(result, &jsonpatch.JsonPatchOperation{
-		Operation: "remove",
-		Path:      path,
-	})
+func removeContainers(path string) jsonpatch.Patch {
+	return []jsonpatch.Operation{internal.RemoveOp(path)}
 }
 
-func addContainers(target, containers []corev1.Container, base string) []*jsonpatch.JsonPatchOperation {
-	var result []*jsonpatch.JsonPatchOperation
+func addContainers(target, containers []corev1.Container, base string) jsonpatch.Patch {
+	var result jsonpatch.Patch
 	first := len(target) == 0
 	var value interface{}
 	for _, container := range containers {
@@ -78,44 +64,21 @@ func addContainers(target, containers []corev1.Container, base string) []*jsonpa
 			path = path + "/-"
 		}
 
-		result = append(result, &jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      path,
-			Value:     value,
-		})
+		result = append(result, internal.AddOp(path, value))
 	}
 
 	return result
 }
 
-func updateAnnotations(target, annotations map[string]string) []*jsonpatch.JsonPatchOperation {
-	var result []*jsonpatch.JsonPatchOperation
+func updateAnnotations(target, annotations map[string]string) jsonpatch.Patch {
+	var result jsonpatch.Patch
 	if len(target) == 0 {
-		result = append(result, &jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      "/metadata/annotations",
-			Value:     annotations,
-		})
-
-		return result
+		return []jsonpatch.Operation{internal.AddOp("/metadata/annotations", annotations)}
 	}
 
 	for key, value := range annotations {
-		result = append(result, &jsonpatch.JsonPatchOperation{
-			Operation: "add",
-			Path:      "/metadata/annotations/" + EscapeJSONPointer(key),
-			Value:     value,
-		})
+		result = append(result, internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(key), value))
 	}
 
 	return result
-}
-
-// EscapeJSONPointer escapes a JSON string to be compliant with the
-// JavaScript Object Notation (JSON) Pointer syntax RFC:
-// https://tools.ietf.org/html/rfc6901.
-func EscapeJSONPointer(s string) string {
-	s = strings.Replace(s, "~", "~0", -1)
-	s = strings.Replace(s, "/", "~1", -1)
-	return s
 }

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -230,7 +230,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	}
 
 	h.Log.Debug("creating patches for the pod..")
-	_, patch, err := agentSidecar.Patch()
+	patch, err := agentSidecar.Patch()
 	if err != nil {
 		err := fmt.Errorf("error creating patch for agent: %s", err)
 		return admissionError(req.UID, err)

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -6,9 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/evanphx/json-patch"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-k8s/agent-inject/agent"
-	"github.com/mattbaird/jsonpatch"
+	"github.com/hashicorp/vault-k8s/agent-inject/internal"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ func TestHandlerHandle(t *testing.T) {
 		Handler Handler
 		Req     admissionv1.AdmissionRequest
 		Err     string // expected error string, not exact
-		Patches []jsonpatch.JsonPatchOperation
+		Patches jsonpatch.Patch
 	}{
 		{
 			"kube-system namespace",
@@ -149,39 +150,15 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -202,47 +179,17 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "remove",
-					Path:      "/spec/initContainers",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/1/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.RemoveOp("/spec/initContainers"),
+				internal.AddOp("/spec/initContainers", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/1/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -262,43 +209,16 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -319,47 +239,17 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -380,43 +270,16 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -438,31 +301,13 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -484,35 +329,14 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 
@@ -533,39 +357,15 @@ func TestHandlerHandle(t *testing.T) {
 				}),
 			},
 			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers/0/volumeMounts/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + agent.EscapeJSONPointer(agent.AnnotationAgentStatus),
-				},
+			[]jsonpatch.Operation{
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/volumes/-", nil),
+				internal.AddOp("/spec/volumes", nil),
+				internal.AddOp("/spec/containers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/initContainers/-", nil),
+				internal.AddOp("/spec/initContainers/0/volumeMounts/-", nil),
+				internal.AddOp("/spec/containers/-", nil),
+				internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(agent.AnnotationAgentStatus), nil),
 			},
 		},
 		{
@@ -601,12 +401,15 @@ func TestHandlerHandle(t *testing.T) {
 				return
 			}
 
-			var actual []jsonpatch.JsonPatchOperation
+			var actual jsonpatch.Patch
 			if len(resp.Patch) > 0 {
 				req.NoError(json.Unmarshal(resp.Patch, &actual))
 				for i := range actual {
-					actual[i].Value = nil
+					delete(actual[i], "value")
 				}
+			}
+			for i := range tt.Patches {
+				delete(tt.Patches[i], "value")
 			}
 			req.Equal(tt.Patches, actual)
 		})

--- a/agent-inject/internal/json_patch_helper.go
+++ b/agent-inject/internal/json_patch_helper.go
@@ -46,7 +46,7 @@ func RemoveOp(path string) jsonpatch.Operation {
 // JavaScript Object Notation (JSON) Pointer syntax RFC:
 // https://tools.ietf.org/html/rfc6901.
 func EscapeJSONPointer(s string) string {
-	s = strings.Replace(s, "~", "~0", -1)
-	s = strings.Replace(s, "/", "~1", -1)
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
 	return s
 }

--- a/agent-inject/internal/json_patch_helper.go
+++ b/agent-inject/internal/json_patch_helper.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"encoding/json"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+var (
+	addOperation    = json.RawMessage(`"add"`)
+	removeOperation = json.RawMessage(`"remove"`)
+)
+
+func AddOp(path string, value interface{}) jsonpatch.Operation {
+	pathBytes, err := json.Marshal(path)
+	if err != nil {
+		panic(err) // shouldn't be possible
+	}
+	valueBytes, err := json.Marshal(value)
+	if err != nil {
+		panic(err) // shouldn't be possible
+	}
+	pathRaw := json.RawMessage(pathBytes)
+	valueRaw := json.RawMessage(valueBytes)
+	return map[string]*json.RawMessage{
+		"op":    &addOperation,
+		"path":  &pathRaw,
+		"value": &valueRaw,
+	}
+}
+
+func RemoveOp(path string) jsonpatch.Operation {
+	pathBytes, err := json.Marshal(path)
+	if err != nil {
+		panic(err) // shouldn't be possible
+	}
+	pathRaw := json.RawMessage(pathBytes)
+	return map[string]*json.RawMessage{
+		"op":   &removeOperation,
+		"path": &pathRaw,
+	}
+}
+
+// EscapeJSONPointer escapes a JSON string to be compliant with the
+// JavaScript Object Notation (JSON) Pointer syntax RFC:
+// https://tools.ietf.org/html/rfc6901.
+func EscapeJSONPointer(s string) string {
+	s = strings.Replace(s, "~", "~0", -1)
+	s = strings.Replace(s, "/", "~1", -1)
+	return s
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.17
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.1
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1
 	github.com/hashicorp/vault/sdk v0.2.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kr/text v0.2.0
-	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
 	github.com/mitchellh/cli v1.1.4
 	github.com/operator-framework/operator-lib v0.8.0
 	github.com/pkg/errors v0.9.1
@@ -30,7 +30,6 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,9 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
@@ -369,8 +370,6 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24 h1:uYuGXJBAi1umT+ZS4oQJUgKtfXCAYTR+n9zw1ViT0vA=
-github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
Switch from `github.com/mattbaird/jsonpatch` (unmaintained) to a new version of `github.com/evanphx/json-patch`.

I also noticed that the `agent.Patches` object is unused, as is the `patches` parameter of `agent.New()`, so I removed those, which simplifies some of the code.

(This is in preparation for some more work involving JSON patches, so I wanted to clean up existing usage of it.)