### PR TITLE
Add exit on error auto auth annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* Support for setting [`exit_on_err`](https://github.com/hashicorp/vault/pull/17091) in the agent auto-auth method config [GH-400](https://github.com/hashicorp/vault-k8s/pull/400).
+
 ## 1.0.1 (October 24, 2022)
 
 Changes:

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -295,6 +295,9 @@ const (
 	// AnnotationAgentInitJsonPatch is used to specify a JSON patch to be applied to the agent init container before
 	// it is created.
 	AnnotationAgentInitJsonPatch = "vault.hashicorp.com/agent-init-json-patch"
+
+	// AnnotationAgentAutoAuthExitOnError is used to control if a failure in the auto_auth method will cause the agent to exit or try indefinitely (the default).
+	AnnotationAgentAutoAuthExitOnError = "vault.hashicorp.com/agent-auto-auth-exit-on-err"
 )
 
 type AgentConfig struct {
@@ -757,6 +760,14 @@ func (a *Agent) templateConfigExitOnRetryFailure() (bool, error) {
 		return DefaultTemplateConfigExitOnRetryFailure, nil
 	}
 
+	return strconv.ParseBool(raw)
+}
+
+func (a *Agent) getAutoAuthExitOnError() (bool, error) {
+	raw, ok := a.Annotations[AnnotationAgentAutoAuthExitOnError]
+	if !ok {
+		return DefaultAutoAuthEnableOnExit, nil
+	}
 	return strconv.ParseBool(raw)
 }
 

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -1142,6 +1142,24 @@ func TestAuthMinMaxBackoff(t *testing.T) {
 	require.Equal(t, "10s", agent.Vault.AuthMaxBackoff, "expected 10s, got %v", agent.Vault.AuthMaxBackoff)
 }
 
+func TestAutoAuthExitOnError(t *testing.T) {
+	pod := testPod(map[string]string{
+		"vault.hashicorp.com/agent-auto-auth-exit-on-err": "true",
+	})
+	agentConfig := basicAgentConfig()
+	err := Init(pod, agentConfig)
+	if err != nil {
+		t.Errorf("got error, shouldn't have: %s", err)
+	}
+
+	agent, err := New(pod)
+	if err != nil {
+		t.Errorf("got error, shouldn't have: %s", err)
+	}
+
+	require.Equal(t, true, agent.AutoAuthExitOnError)
+}
+
 func TestDisableIdleConnections(t *testing.T) {
 	tests := map[string]struct {
 		annotations   map[string]string

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -58,6 +58,7 @@ type Method struct {
 	MaxBackoff string                 `json:"max_backoff,omitempty"`
 	Namespace  string                 `json:"namespace,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
+	ExitOnErr  bool                   `json:"exit_on_err,omitempty"`
 }
 
 // Sink defines a location to write the authenticated token
@@ -177,6 +178,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 				Config:     a.Vault.AuthConfig,
 				MinBackoff: a.Vault.AuthMinBackoff,
 				MaxBackoff: a.Vault.AuthMaxBackoff,
+				ExitOnErr:  a.AutoAuthExitOnError,
 			},
 			Sinks: []*Sink{
 				{


### PR DESCRIPTION
Support was added in the Vault agent in https://github.com/hashicorp/vault/pull/17091

Additionally, I tested this on a cluster by adding the `vault.hashicorp.com/agent-auto-auth-exit-on-err: "true"` annotation on a pod, and observing that the agent configuration was:

```json
{
  "auto_auth": {
    "method": {
      "type": "kubernetes",
      "mount_path": "auth/kubernetes",
      "config": {
        "role": "internal-app",
        "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"
      },
      "exit_on_err": true
    }...
```