### PR TITLE
Set Kubernetes user-agent to include version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Unreleased
 
-Improvements:
+Changes:
 * Building with Go 1.19.4 [GH-406](https://github.com/hashicorp/vault-k8s/pull/406)
 * Update golang.org/x/net to v0.4.0 [GH-409](https://github.com/hashicorp/vault-k8s/pull/409)
+* Set Kubernetes user-agent to include vault-k8s version [GH-411](https://github.com/hashicorp/vault-k8s/pull/411)
+
+Improvements:
 * Add support for enabling `sharedProcessNamespace` on the Pod `spec` [GH-408](https://github.com/hashicorp/vault-k8s/pull/408)
 
 Bugs:

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -22,6 +22,7 @@ import (
 	agentInject "github.com/hashicorp/vault-k8s/agent-inject"
 	"github.com/hashicorp/vault-k8s/helper/cert"
 	"github.com/hashicorp/vault-k8s/leader"
+	"github.com/hashicorp/vault-k8s/version"
 	"github.com/mitchellh/cli"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	adminv1 "k8s.io/api/admissionregistration/v1"
@@ -117,6 +118,7 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error loading in-cluster K8S config: %s", err))
 		return 1
 	}
+	config.UserAgent = fmt.Sprintf("vault-k8s/%s", version.Version)
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
We weren't setting the user-agent, so Kubernetes sets a default of the command-line (`vault-k8s`, which is okay) and an automatically set version in the Kubernetes code base. This is probably not what we want, since it implies that the Kubernetes version is the `vault-k8s` version, and it is often just `0.0.0`. See https://github.com/kubernetes/client-go/blob/master/pkg/version/base.go

Instead, we set the user-agent based on our own version.

I didn't see an easy way to test this in a unit test, but I did test it manually by running `vault-k8s` with the environment variable `GODEBUG=http2debug=1` set.