### PR TITLE
Add SeccompProfile to SecurityContext

### DIFF
--- a/agent-inject/agent/\
+++ b/agent-inject/agent/\
@@ -1336,9 +1336,6 @@ func TestAgentJsonPatch(t *testing.T) {
 			RunAsNonRoot:             optional[bool](true),
 			ReadOnlyRootFilesystem:   optional[bool](true),
 			AllowPrivilegeEscalation: optional[bool](false),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
 		},
 	}
 

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -239,5 +239,8 @@ func (a *Agent) securityContext() *corev1.SecurityContext {
 			Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 		},
 		AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 }


### PR DESCRIPTION
The generated sidecar violates the PodSecurity `restricted` and therefore is not admitted:

``` 
Warning  FailedCreate  3m23s (x8 over 8m48s)  replicaset-controller  (combined from similar events): Error creating: pods "perfana-grafana-79b685674b-rgfsf" is forbidden: violates PodSecurity "restricted:latest": seccompProfile (pod or containers "vault-agent-init", "vault-agent" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

As a result, we have to lower our security standard to `pod-security.kubernetes.io/enforce:  baseline`.

This pull request adds `SeccompProfile` to the generates `secuirtContext` for the sidecar.

Also noted in https://github.com/hashicorp/vault-k8s/issues/377.