### PR TITLE
dockerfile: explicit alpine versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,6 +18,6 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     reviewers:
       - "hashicorp/vault-ecosystem-foundations"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@
 # `default` is the production docker image which cannot be built locally. 
 # For local dev and testing purposes, please build and use the `dev` docker image.
 
-ARG ALPINE_VERSION=3.17.1
-
-FROM docker.mirror.hashicorp.services/alpine:${ALPINE_VERSION} as dev
+FROM docker.mirror.hashicorp.services/alpine:3.17.1 as dev
 
 RUN addgroup vault && \
     adduser -S -G vault vault
@@ -26,7 +24,7 @@ USER vault
 ENTRYPOINT ["/vault-k8s"]
 
 # This target creates a production release image for the project.
-FROM docker.mirror.hashicorp.services/alpine:${ALPINE_VERSION} as default
+FROM docker.mirror.hashicorp.services/alpine:3.17.1 as default
 
 # PRODUCT_VERSION is the tag built, e.g. v0.1.0
 # PRODUCT_REVISION is the git hash built


### PR DESCRIPTION
Made the alpine image versions explicit so dependabot can parse them for updates. Also increased the docker update frequency to daily, to pick up UBI image updates in particular, since security issues with them will not be caught until they're submitted to redhat.