### PR TITLE
Updated dockerfile to use alpine 3.16.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # `default` is the production docker image which cannot be built locally. 
 # For local dev and testing purposes, please build and use the `dev` docker image.
 
-FROM docker.mirror.hashicorp.services/alpine:3.17.2 as dev
+FROM docker.mirror.hashicorp.services/alpine:3.16.4 as dev
 
 RUN addgroup vault && \
     adduser -S -G vault vault
@@ -24,7 +24,7 @@ USER vault
 ENTRYPOINT ["/vault-k8s"]
 
 # This target creates a production release image for the project.
-FROM docker.mirror.hashicorp.services/alpine:3.17.2 as default
+FROM docker.mirror.hashicorp.services/alpine:3.16.4 as default
 
 # PRODUCT_VERSION is the tag built, e.g. v0.1.0
 # PRODUCT_REVISION is the git hash built


### PR DESCRIPTION
Updated dockerfile to use alpine 3.16.4 to address below CVEs

CVE-2022-4203
CVE-2022-4304
CVE-2022-4450
CVE-2023-0215
CVE-2023-0216
CVE-2023-0217
CVE-2023-0286
CVE-2023-0401


```
kabhijeet@vm-kabhijeet:/localdata/vault/cna-vault$ trivy image hashicorp/vault-k8s:1.2
2023-03-14T14:14:02.496Z	INFO	Vulnerability scanning is enabled
2023-03-14T14:14:02.496Z	INFO	Secret scanning is enabled
2023-03-14T14:14:02.496Z	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-03-14T14:14:02.496Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.36/docs/secret/scanning/#recommendation for faster secret detection
2023-03-14T14:14:04.881Z	INFO	Detected OS: alpine
2023-03-14T14:14:04.881Z	INFO	Detecting Alpine vulnerabilities...
2023-03-14T14:14:04.940Z	INFO	Number of language-specific files: 1
2023-03-14T14:14:04.940Z	INFO	Detecting gobinary vulnerabilities...


hashicorp/vault-k8s:1.2 (alpine 3.17.1)

Total: 16 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 12, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2022-4450 │ HIGH     │ 3.0.7-r2          │ 3.0.8-r0      │ openssl: double free after calling PEM_read_bio_ex          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215 │          │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216 │          │                   │               │ openssl: invalid pointer dereference in d2i_PKCS7 functions │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217 │          │                   │               │ openssl: NULL dereference validating DSA public key         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286 │          │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401 │          │                   │               │ openssl: NULL dereference during PKCS7 data verification    │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                   │
│            ├───────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203 │ MEDIUM   │                   │               │ openssl: read buffer overflow in X.509 certificate          │
│            │               │          │                   │               │ verification                                                │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304 │          │                   │               │ openssl: timing attack in RSA Decryption implementation     │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
├────────────┼───────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2022-4450 │ HIGH     │                   │               │ openssl: double free after calling PEM_read_bio_ex          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215 │          │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216 │          │                   │               │ openssl: invalid pointer dereference in d2i_PKCS7 functions │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217 │          │                   │               │ openssl: NULL dereference validating DSA public key         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286 │          │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401 │          │                   │               │ openssl: NULL dereference during PKCS7 data verification    │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                   │
│            ├───────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203 │ MEDIUM   │                   │               │ openssl: read buffer overflow in X.509 certificate          │
│            │               │          │                   │               │ verification                                                │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                   │
│            ├───────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304 │          │                   │               │ openssl: timing attack in RSA Decryption implementation     │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

bin/vault-k8s (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                           │
├──────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2022-41723 │ HIGH     │ v0.4.0            │ 0.7.0         │ A maliciously crafted HTTP/2 stream could cause excessive │
│                  │                │          │                   │               │ CPU consumpt ...                                          │
│                  │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41723                │
└──────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```