### PR TITLE
Possibility to use template and template-file annotations without sec…

### DIFF
--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -29,7 +29,6 @@ func TestNewConfig(t *testing.T) {
 		AnnotationVaultClientKey:                        "client-key",
 		AnnotationVaultSecretVolumePath:                 "/vault/secrets",
 		AnnotationProxyAddress:                          "http://proxy:3128",
-		"vault.hashicorp.com/agent-inject-secret-foo":   "db/creds/foo",
 		"vault.hashicorp.com/agent-inject-template-foo": "template foo",
 		"vault.hashicorp.com/agent-inject-secret-bar":   "db/creds/bar",
 
@@ -38,7 +37,6 @@ func TestNewConfig(t *testing.T) {
 		fmt.Sprintf("%s-%s", AnnotationVaultSecretVolumePath, "different-path"): "/etc/container_environment",
 
 		// render this secret from a template on disk
-		"vault.hashicorp.com/agent-inject-secret-with-file-template":                  "with-file-template",
 		fmt.Sprintf("%s-%s", AnnotationAgentInjectTemplateFile, "with-file-template"): "/etc/file-template",
 
 		"vault.hashicorp.com/agent-inject-command-bar": "pkill -HUP app",
@@ -809,7 +807,7 @@ func TestConfigTelemetry(t *testing.T) {
 				"vault.hashicorp.com/agent-telemetry-stackdriver_location":                   "useast-1",
 				"vault.hashicorp.com/agent-telemetry-stackdriver_namespace":                  "foo",
 				"vault.hashicorp.com/agent-telemetry-stackdriver_debug_logs":                 "false",
-				"vault.hashicorp.com/agent-telemetry-prefix_filter":                          `["+vault.token", "-vault.expire", "+vault.expire.num_leases"]`, 
+				"vault.hashicorp.com/agent-telemetry-prefix_filter":                          `["+vault.token", "-vault.expire", "+vault.expire.num_leases"]`,
 			},
 			&Telemetry{
 				UsageGaugePeriod:                   "10m",


### PR DESCRIPTION
## Summary
This Pull Request introduces enhancements to the Vault Kubernetes integration by simplifying the secret injection process. Specifically, it removes the need for the redundant and ineffective `vault.hashicorp.com/agent-inject-secret-foo: someKey` annotation.

## Motivation
In the current implementation, users are required to include the `vault.hashicorp.com/agent-inject-secret-foo: someKey` annotation in their configuration. However, this annotation doesn't contribute to the functionality and only adds unnecessary complexity.

## Changes Introduced
With this PR, users will no longer need to specify the `vault.hashicorp.com/agent-inject-secret-foo: someKey` annotation. Instead, the necessary information about secrets can be fully determined by the provided templates or template files, such as `vault.hashicorp.com/agent-inject-template-foo: "{{- with secret "someKey" -}} {{- end }}"` or `vault.hashicorp.com/agent-inject-template-file-foo: "someFile"`. 
This results in a cleaner and more intuitive configuration.
