### PR TITLE
Added the ability to configure template delimiters on Pod annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.3.0 (August 16, 2023)
 
 Improvements:
+* Added support to configure template delimiters through Pod Annotations [GH-517](https://github.com/hashicorp/vault-k8s/pull/517)
+
+Improvements:
 * Add `NAMESPACE`, `HOST_IP`, and `POD_IP` environment variables to Agent container using downward API [GH-486](https://github.com/hashicorp/vault-k8s/pull/486)
 
 Changes:

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -268,6 +268,14 @@ const (
 	// attempts. Defaults to true.
 	AnnotationTemplateConfigExitOnRetryFailure = "vault.hashicorp.com/template-config-exit-on-retry-failure"
 
+	// AnnotationTemplateConfigLeftDelimiters template delimiters
+	// Defaults to "{{".
+	AnnotationTemplateConfigLeftDelimiters = "vault.hashicorp.com/template-left-delimiter"
+
+	// AnnotationTemplateConfigLeftDelimiters template delimiters
+	// Defaults to "{{".
+	AnnotationTemplateConfigRightDelimiters = "vault.hashicorp.com/template-right-delimiter"
+
 	// AnnotationTemplateConfigStaticSecretRenderInterval
 	// If specified, configures how often Vault Agent Template should render non-leased secrets such as KV v2.
 	// Defaults to 5 minutes.

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -198,12 +198,13 @@ func (a *Agent) newTemplateConfigs() []*Template {
 			filePathAndName = filepath.Join(secret.MountPath, secret.FilePathAndName)
 		}
 
+		leftDelim, rightDelim := a.getTemplateConfigDelimiters()
 		tmpl := &Template{
 			Source:      templateFile,
 			Contents:    template,
 			Destination: filePathAndName,
-			LeftDelim:   "{{",
-			RightDelim:  "}}",
+			LeftDelim:   leftDelim,
+			RightDelim:  rightDelim,
 			Command:     secret.Command,
 		}
 		if secret.FilePermission != "" {
@@ -212,6 +213,21 @@ func (a *Agent) newTemplateConfigs() []*Template {
 		templates = append(templates, tmpl)
 	}
 	return templates
+}
+
+func (a *Agent) getTemplateConfigDelimiters() (string, string) {
+	leftDelim := "{{"
+	rightDelim := "}}"
+
+	if left, defined := a.Annotations[AnnotationTemplateConfigLeftDelimiters]; defined {
+		leftDelim = left
+	}
+
+	if right, defined := a.Annotations[AnnotationTemplateConfigRightDelimiters]; defined {
+		rightDelim = right
+	}
+
+	return leftDelim, rightDelim
 }
 
 func (a *Agent) newConfig(init bool) ([]byte, error) {


### PR DESCRIPTION
There are some custom resources where Pod templates are used, and their respective controllers may run some template engine on top of it using the same configured templates delimiters (e.g: [argo rollouts](https://argo-rollouts.readthedocs.io/en/stable/features/analysis/) analysis template), causing errors due to conflicting delimiters. This PR adds the ability to configure consul template delimiters though Pod annotations. 