### PR TITLE
fix: prevent using IRSA token for Kubernetes auth

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -781,6 +781,10 @@ func serviceaccount(pod *corev1.Pod) (*ServiceAccountTokenVolume, error) {
 	for _, container := range pod.Spec.Containers {
 		for _, volumes := range container.VolumeMounts {
 			if strings.Contains(volumes.MountPath, "serviceaccount") {
+				// Prevent using IRSA token for Kubernetes auth
+				if strings.Contains(volumes.MountPath, "eks.amazonaws.com") {
+					continue
+				}
 				return &ServiceAccountTokenVolume{
 					Name:      volumes.Name,
 					MountPath: volumes.MountPath,


### PR DESCRIPTION
Summary
Skip IRSA token when detecting the service account token to use for the Kubernetes auth method.

I tried to follow the same logic used elsewhere for detecting the IRSA token.

Fixes
https://github.com/hashicorp/vault-k8s/issues/544