### PR TITLE
update alpine image to fix CVE023-6129, 2024-0727 2023-62372

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # `default` is the production docker image which cannot be built locally. 
 # For local dev and testing purposes, please build and use the `dev` docker image.
 
-FROM docker.mirror.hashicorp.services/alpine:3.19.0 as dev
+FROM docker.mirror.hashicorp.services/alpine:3.19.1 as dev
 
 RUN addgroup vault && \
     adduser -S -G vault vault
@@ -24,7 +24,7 @@ USER vault
 ENTRYPOINT ["/vault-k8s"]
 
 # This target creates a production release image for the project.
-FROM docker.mirror.hashicorp.services/alpine:3.19.0 as default
+FROM docker.mirror.hashicorp.services/alpine:3.19.1 as default
 
 # PRODUCT_VERSION is the tag built, e.g. v0.1.0
 # PRODUCT_REVISION is the git hash built


### PR DESCRIPTION
Resolves recent openssl CVEs:

```

## Packages and Vulnerabilities

   0C     0H     1M     0L     2?  openssl 3.1.4-r2
pkg:apk/alpine/openssl@3.1.4-r2?os_name=alpine&os_version=3.19

    ✗ MEDIUM CVE-2023-6129
      https://scout.docker.com/v/CVE-2023-6129?s=alpine&n=openssl&ns=alpine&t=apk&osn=alpine&osv=3.19&vr=%3C3.1.4-r3
      Affected range : <3.1.4-r3
      Fixed version  : 3.1.4-r3

    ✗ UNSPECIFIED CVE-2024-0727
      https://scout.docker.com/v/CVE-2024-0727?s=alpine&n=openssl&ns=alpine&t=apk&osn=alpine&osv=3.19&vr=%3C3.1.4-r5
      Affected range : <3.1.4-r5
      Fixed version  : 3.1.4-r5

    ✗ UNSPECIFIED CVE-2023-6237
      https://scout.docker.com/v/CVE-2023-6237?s=alpine&n=openssl&ns=alpine&t=apk&osn=alpine&osv=3.19&vr=%3C3.1.4-r4
      Affected range : <3.1.4-r4
      Fixed version  : 3.1.4-r4



3 vulnerabilities found in 1 package
  UNSPECIFIED  2
  LOW          0
  MEDIUM       1
  HIGH         0
  CRITICAL     0

```