### PR TITLE
enable logging from operator-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* Enable logging from operator-lib's leader election (used during auto-tls certificate generation) [GH-608](https://github.com/hashicorp/vault-k8s/pull/608)
+
 ## 1.4.0 (March 4, 2024)
 
 Features:

--- a/deploy/injector-rbac.yaml
+++ b/deploy/injector-rbac.yaml
@@ -25,6 +25,10 @@ rules:
     - "list"
     - "watch"
     - "patch"
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs:
+    - "get"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/evanphx/json-patch v5.9.0+incompatible
+	github.com/go-logr/logr v1.3.0
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3
@@ -21,6 +22,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+	sigs.k8s.io/controller-runtime v0.16.3
 )
 
 require (
@@ -35,7 +37,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.14.1 // indirect
-	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
@@ -85,7 +86,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	sigs.k8s.io/controller-runtime v0.16.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/leader/logger.go
+++ b/leader/logger.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Borrowed from https://github.com/hashicorp/consul-api-gateway/blob/main/internal/k8s/logger.go
+
+package leader
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func fromHCLogger(log hclog.Logger) logr.Logger {
+	return logr.New(&logger{log})
+}
+
+// logger is a LogSink that wraps hclog
+type logger struct {
+	hclog.Logger
+}
+
+// Verify that it actually implements the interface
+var _ logr.LogSink = logger{}
+
+func (l logger) Init(logr.RuntimeInfo) {
+}
+
+func (l logger) Enabled(_ int) bool {
+	return true
+}
+
+// Info actually logs as debug here, since operator-lib's Info logs are pretty
+// chatty, and seem to fit better as debug
+func (l logger) Info(_ int, msg string, keysAndValues ...interface{}) {
+	if l.Logger.GetLevel() <= hclog.Debug {
+		l.Logger.Debug(msg, keysAndValues...)
+	}
+}
+
+func (l logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	keysAndValues = append([]interface{}{"error", err}, keysAndValues...)
+	l.Logger.Error(msg, keysAndValues...)
+}
+
+func (l logger) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return &logger{l.With(keysAndValues...)}
+}
+
+func (l logger) WithName(name string) logr.LogSink {
+	return &logger{l.Named(name)}
+}

--- a/leader/logger.go
+++ b/leader/logger.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Borrowed from https://github.com/hashicorp/consul-api-gateway/blob/main/internal/k8s/logger.go
+// Borrowed from https://github.com/hashicorp/consul-api-gateway/blob/4ca5788fa357e389336049bd652f28309ee29d4a/internal/k8s/logger.go
 
 package leader
 


### PR DESCRIPTION
Uses a logging type from consul to wrap an hclog logger in logr's LogSink type. This also turned up a missing ClusterRole permission for getting Nodes from k8s.

Fixes #605 

ClusterRole permissions also added to the chart in https://github.com/hashicorp/vault-helm/pull/1005

Related to https://github.com/hashicorp/vault-helm/issues/980 and https://github.com/hashicorp/vault-helm/issues/725

Log samples:

```
[ERROR] handler.operator-lib.leader: Failed to get Node: error="nodes \"kind-control-plane\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot get resource \"nodes\" in API group \"\" at the cluster scope" Node.Name=kind-control-plane
[DEBUG] handler.operator-lib.leader: Not the leader. Waiting.
```