### PR TITLE
Add native sidecar support

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -86,6 +86,10 @@ type Agent struct {
 	// added to the request.
 	PrePopulateOnly bool
 
+	// NativeSidecar controls whether a native sidecar container (init container
+	// that stays running) is added to the pod.
+	NativeSidecar bool
+
 	// RevokeOnShutdown controls whether a sidecar container will attempt to revoke its Vault
 	// token on shutting down.
 	RevokeOnShutdown bool
@@ -407,6 +411,11 @@ func New(pod *corev1.Pod) (*Agent, error) {
 		},
 	}
 
+	agent.NativeSidecar, err = agent.nativeSidecar()
+	if err != nil {
+		return agent, err
+	}
+
 	agent.Secrets, err = agent.secrets()
 	if err != nil {
 		return agent, err
@@ -645,8 +654,8 @@ func (a *Agent) Patch() ([]byte, error) {
 	}
 
 	// Init Container
-	if a.PrePopulate {
-		container, err := a.ContainerInitSidecar()
+	if a.PrePopulate || a.NativeSidecar {
+		container, err := a.ContainerInitSidecar(a.NativeSidecar)
 		if err != nil {
 			return nil, err
 		}
@@ -696,7 +705,7 @@ func (a *Agent) Patch() ([]byte, error) {
 	}
 
 	// Sidecar Container
-	if !a.PrePopulateOnly {
+	if !a.PrePopulateOnly && !a.NativeSidecar {
 		container, err := a.ContainerSidecar()
 		if err != nil {
 			return nil, err
@@ -755,6 +764,14 @@ func (a *Agent) Validate() error {
 			return errors.New("no Vault address found")
 		}
 	}
+
+	if a.NativeSidecar && a.PrePopulateOnly {
+		return errors.New("cannot set native sidecar and prepopulate only")
+	}
+
+	// TODO(tvoran): we should probably prevent any of the other sidecar/init
+	// container settings when NativeSidecar is set
+
 	return nil
 }
 

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -323,6 +323,11 @@ const (
 	// should map to the same unique value provided in
 	// "vault.hashicorp.com/agent-inject-secret-". Defaults to false
 	AnnotationErrorOnMissingKey = "vault.hashicorp.com/error-on-missing-key"
+
+	// AnnotationNativeSidecar is the key of the annotation that configures
+	// whether a native sidecar container (init container that stays running) is
+	// added to the pod.
+	AnnotationNativeSidecar = "vault.hashicorp.com/agent-native-sidecar"
 )
 
 type AgentConfig struct {
@@ -711,6 +716,15 @@ func (a *Agent) prePopulate() (bool, error) {
 
 func (a *Agent) prePopulateOnly() (bool, error) {
 	raw, ok := a.Annotations[AnnotationAgentPrePopulateOnly]
+	if !ok {
+		return false, nil
+	}
+
+	return parseutil.ParseBool(raw)
+}
+
+func (a *Agent) nativeSidecar() (bool, error) {
+	raw, ok := a.Annotations[AnnotationNativeSidecar]
 	if !ok {
 		return false, nil
 	}

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -1255,7 +1255,7 @@ func TestContainerCache(t *testing.T) {
 			err = agent.Validate()
 			require.NoError(t, err)
 
-			init, err := agent.ContainerInitSidecar()
+			init, err := agent.ContainerInitSidecar(false)
 			require.NoError(t, err)
 
 			sidecar, err := agent.ContainerSidecar()
@@ -1458,7 +1458,7 @@ func TestAgentJsonPatch(t *testing.T) {
 
 			var sidecar corev1.Container
 			if tt.init {
-				sidecar, err = agent.ContainerInitSidecar()
+				sidecar, err = agent.ContainerInitSidecar(false)
 			} else {
 				sidecar, err = agent.ContainerSidecar()
 			}


### PR DESCRIPTION
PoC for implementing https://github.com/hashicorp/vault-k8s/issues/620

Adds a new annotation `vault.hashicorp.com/agent-native-sidecar` to inject Vault Agent as a [native sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/). Adds a startupProbe that looks for `/home/vault/.native-sidecar-started`.