### PR TITLE
Test with latest vault-helm and Vault 1.17

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -22,6 +22,9 @@ inputs:
   bats-version:
     description: 'Version of bats to run tests with'
     default: '1.11.0'
+  vault-license:
+    description: 'Vault license to use for enterprise tests'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -47,7 +50,7 @@ runs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: "hashicorp/vault-helm"
-        ref: "v0.28.0"
+        ref: "v0.28.1"
         path: "vault-helm"
 
     - name: Create Kind Cluster
@@ -88,6 +91,8 @@ runs:
     - name: bats tests
       shell: bash
       working-directory: vault-helm
+      env:
+        VAULT_LICENSE_CI: ${{ inputs.vault-license }}
       run: |
         # assumes Python based yq :(
         yq --in-place --yaml-roundtrip '.injector.image.tag |= "${{ inputs.version }}"' ./values.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions.
       K8S_VERSIONS: '["1.30.0", "1.29.4", "1.28.9", "1.27.13", "1.26.15"]'
-      VAULT_N: "1.17.1"
+      VAULT_N: "1.17.2"
       VAULT_N_1: "1.16.3"
       VAULT_N_2: "1.15.6"
 
@@ -66,6 +66,7 @@ jobs:
           vault-version: ${{ matrix.vault-version }}
           tarball-file: ${{ needs.test.outputs.tarball_file }}
           version: ${{ needs.test.outputs.version }}
+          vault-license: ${{ secrets.VAULT_LICENSE_CI }}
 
   latest-k8s:
     name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }}
@@ -90,3 +91,4 @@ jobs:
           vault-version: ${{ matrix.vault-version }}
           tarball-file: ${{ needs.test.outputs.tarball_file }}
           version: ${{ needs.test.outputs.version }}
+          vault-license: ${{ secrets.VAULT_LICENSE_CI }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## Unreleased
 
+Changes:
+* Default Vault version updated to 1.17.2
+
 ## 1.4.2 (July 3, 2024)
 
 Changes:
 * Building with Go 1.22.5
-* Default Vault version update to 1.17.1
+* Default Vault version updated to 1.17.1
 * Testing with Vault 1.15 - 1.17
 * Dependency updates:
   * Docker image `alpine` 3.19.1 => 3.20.1
@@ -28,7 +31,7 @@ Changes:
 
 Changes:
 * Building with Go 1.22.2
-* Default Vault version update to 1.16.1
+* Default Vault version updated to 1.16.1
 * Dependency updates:
   * Docker UBI image `ubi8/ubi-minimal` 8.9-1137 => 8.9-1161
   * `github.com/cenkalti/backoff/v4` v4.2.1 => v4.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY_NAME ?= docker.io/hashicorp
 IMAGE_NAME = vault-k8s
 VERSION ?= 0.0.0-dev
-VAULT_VERSION ?= 1.17.1
+VAULT_VERSION ?= 1.17.2
 IMAGE_TAG ?= $(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
 PUBLISH_LOCATION ?= https://releases.hashicorp.com
 DOCKER_DIR = ./build/docker
@@ -15,7 +15,7 @@ PKG = github.com/hashicorp/vault-k8s/version
 LDFLAGS ?= "-X '$(PKG).Version=v$(VERSION)'"
 TESTARGS ?= '-test.v'
 
-VAULT_HELM_CHART_VERSION ?= 0.28.0
+VAULT_HELM_CHART_VERSION ?= 0.28.1
 # TODO: add support for testing against enterprise
 
 TEST_WITHOUT_VAULT_TLS ?=

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DefaultVaultImage                       = "hashicorp/vault:1.17.1"
+	DefaultVaultImage                       = "hashicorp/vault:1.17.2"
 	DefaultVaultAuthType                    = "kubernetes"
 	DefaultVaultAuthPath                    = "auth/kubernetes"
 	DefaultAgentRunAsUser                   = 100

--- a/deploy/injector-deployment.yaml
+++ b/deploy/injector-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: AGENT_INJECT_VAULT_ADDR
               value: "https://vault.$(NAMESPACE).svc:8200"
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "hashicorp/vault:1.17.1"
+              value: "hashicorp/vault:1.17.2"
             - name: AGENT_INJECT_TLS_AUTO
               value: vault-agent-injector-cfg
             - name: AGENT_INJECT_TLS_AUTO_HOSTS

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -119,7 +119,7 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_VAULT_CACERT_BYTES", value: "foo", cmdPtr: &cmd.flagVaultCACertBytes},
 		{env: "AGENT_INJECT_PROXY_ADDR", value: "http://proxy:3128", cmdPtr: &cmd.flagProxyAddress},
 		{env: "AGENT_INJECT_VAULT_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagVaultAuthPath},
-		{env: "AGENT_INJECT_VAULT_IMAGE", value: "hashicorp/vault:1.17.1", cmdPtr: &cmd.flagVaultImage},
+		{env: "AGENT_INJECT_VAULT_IMAGE", value: "hashicorp/vault:1.17.2", cmdPtr: &cmd.flagVaultImage},
 		{env: "AGENT_INJECT_VAULT_NAMESPACE", value: "test-namespace", cmdPtr: &cmd.flagVaultNamespace},
 		{env: "AGENT_INJECT_TLS_KEY_FILE", value: "server.key", cmdPtr: &cmd.flagKeyFile},
 		{env: "AGENT_INJECT_TLS_CERT_FILE", value: "server.crt", cmdPtr: &cmd.flagCertFile},


### PR DESCRIPTION
Use vault-helm v0.28.1 and Vault 1.17.2. Set the vault license for the tests since there's a cross-namespace test for the injector in vault-helm now.