### PR TITLE
Test with latest vault-helm v0.29.0

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -50,7 +50,7 @@ runs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: "hashicorp/vault-helm"
-        ref: "v0.28.1"
+        ref: "v0.29.0"
         path: "vault-helm"
 
     - name: Create Kind Cluster

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PKG = github.com/hashicorp/vault-k8s/version
 LDFLAGS ?= "-X '$(PKG).Version=v$(VERSION)'"
 TESTARGS ?= '-test.v'
 
-VAULT_HELM_CHART_VERSION ?= 0.28.1
+VAULT_HELM_CHART_VERSION ?= 0.29.0
 # TODO: add support for testing against enterprise
 
 TEST_WITHOUT_VAULT_TLS ?=


### PR DESCRIPTION
Updating the vault-helm version after the [v0.29.0](https://github.com/hashicorp/vault-helm/releases/tag/v0.29.0) release.