### PR TITLE
ci: latest five k8s kind versions

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -50,7 +50,7 @@ runs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: "hashicorp/vault-helm"
-        ref: "v0.28.1"
+        ref: "v0.29.0"
         path: "vault-helm"
 
     - name: Create Kind Cluster
@@ -59,7 +59,7 @@ runs:
         cluster_name: ${{ inputs.kind-cluster-name }}
         config: vault-helm/test/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
-        version: "v0.24.0"
+        version: "v0.25.0"
 
     - name: Create kind export log root
       id: create_kind_export_log_root

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: echo "setting versions"
     outputs:
       # JSON encoded array of k8s versions.
-      K8S_VERSIONS: '["1.31.1", "1.30.4", "1.29.8", "1.28.13"]'
+      K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.15", "1.27.16"]'
       VAULT_N: "1.18.1"
       VAULT_N_1: "1.17.6"
       VAULT_N_2: "1.16.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changes:
 * Building with Go 1.22.8
 * Default Vault version updated to 1.18.1
 * Testing with Vault 1.16 - 1.18
-* Testing with K8s versions 1.28 - 1.31
+* Testing with K8s versions 1.27 - 1.31
 * Dependency updates:
   * Docker image `alpine` 3.20.1 => 3.20.3
   * Docker image `ubi8/ubi-minimal` 8.10-1018 => 8.10-1086

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PKG = github.com/hashicorp/vault-k8s/version
 LDFLAGS ?= "-X '$(PKG).Version=v$(VERSION)'"
 TESTARGS ?= '-test.v'
 
-VAULT_HELM_CHART_VERSION ?= 0.28.1
+VAULT_HELM_CHART_VERSION ?= 0.29.0
 # TODO: add support for testing against enterprise
 
 TEST_WITHOUT_VAULT_TLS ?=


### PR DESCRIPTION
Test with the last five k8s versions in kind (to match the other k8s projects), and use the latest [kind node versions](https://hub.docker.com/r/kindest/node/tags).

<!-- VAULT-32492 -->