### PR TITLE
fix(metrics): sidecar injection false positives

### DIFF
--- a/agent-inject/metrics.go
+++ b/agent-inject/metrics.go
@@ -49,6 +49,10 @@ var (
 )
 
 func incrementInjections(namespace string, res MutateResponse) {
+	if !res.InjectedInit && !res.InjectedSidecar {
+		return
+	}
+
 	// Injection type can be one of: init_and_sidecar (default); init_only; or sidecar_only
 	typeLabel := metricsLabelTypeBoth
 	if res.InjectedInit && !res.InjectedSidecar {


### PR DESCRIPTION
Do not increment the `injections_by_namespace` metric when no injection is performed.