### PR TITLE
Adding support for exit after auth as an annotation

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -90,6 +90,9 @@ type Agent struct {
 	// token on shutting down.
 	RevokeOnShutdown bool
 
+	// ExitAfterAuth is used to control if the agent should exit after a successful auth.
+	ExitAfterAuth bool
+
 	// RevokeGrace controls after receiving the signal for pod
 	// termination that the container will attempt to revoke its own Vault token.
 	RevokeGrace uint64
@@ -443,6 +446,11 @@ func New(pod *corev1.Pod) (*Agent, error) {
 	agent.RevokeOnShutdown, err = agent.revokeOnShutdown()
 	if err != nil {
 		return agent, err
+	}
+
+	agent.ExitAfterAuth, err = agent.getExitAfterAuth()
+	if err != nil {
+		return nil, err
 	}
 
 	agent.Containers = strings.Split(pod.Annotations[AnnotationAgentInjectContainers], ",")

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -59,6 +59,7 @@ type Handler struct {
 	Clientset                  *kubernetes.Clientset
 	Log                        hclog.Logger
 	RevokeOnShutdown           bool
+	ExitAfterAuth              bool
 	UserID                     string
 	GroupID                    string
 	SameID                     bool
@@ -229,6 +230,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) MutateResponse {
 		ProxyAddress:               h.ProxyAddress,
 		Namespace:                  req.Namespace,
 		RevokeOnShutdown:           h.RevokeOnShutdown,
+		ExitAfterAuth:              h.ExitAfterAuth,
 		UserID:                     h.UserID,
 		GroupID:                    h.GroupID,
 		SameID:                     h.SameID,

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -64,6 +64,7 @@ type Command struct {
 	flagVaultAuthPath              string // Mount path of the Vault Auth Method
 	flagVaultNamespace             string // Vault enterprise namespace
 	flagRevokeOnShutdown           bool   // Revoke Vault Token on pod shutdown
+	flagExitAfterAuth              bool   // Exit after successful auth
 	flagRunAsUser                  string // User (uid) to run Vault agent as
 	flagRunAsGroup                 string // Group (gid) to run Vault agent as
 	flagRunAsSameUser              bool   // Run Vault agent as the User (uid) of the first application container
@@ -208,6 +209,7 @@ func (c *Command) Run(args []string) int {
 		RequireAnnotation:          true,
 		Log:                        logger,
 		RevokeOnShutdown:           c.flagRevokeOnShutdown,
+		ExitAfterAuth:              c.flagExitAfterAuth,
 		UserID:                     c.flagRunAsUser,
 		GroupID:                    c.flagRunAsGroup,
 		SameID:                     c.flagRunAsSameUser,

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -92,6 +92,9 @@ type Specification struct {
 	// RevokeOnShutdown is AGENT_INJECT_REVOKE_ON_SHUTDOWN environment variable.
 	RevokeOnShutdown string `split_words:"true"`
 
+	// ExitAfterAuth is the AGENT_INJECT_EXIT_AFTER_AUTH environment variable.
+	ExitAfterAuth string `split_words:"true"`
+
 	// RunAsUser is the AGENT_INJECT_RUN_AS_USER environment variable. (uid)
 	RunAsUser string `envconfig:"AGENT_INJECT_RUN_AS_USER"`
 
@@ -187,6 +190,8 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagVaultNamespace, "vault-namespace", "", "Vault enterprise namespace.")
 	c.flagSet.BoolVar(&c.flagRevokeOnShutdown, "revoke-on-shutdown", false,
 		"Automatically revoke Vault Token on Pod termination.")
+	c.flagSet.BoolVar(&c.flagExitAfterAuth, "exit-after-auth", false,
+		"Exit after successful authentication to Vault.")
 	c.flagSet.StringVar(&c.flagRunAsUser, "run-as-user", strconv.Itoa(agent.DefaultAgentRunAsUser),
 		fmt.Sprintf("User (uid) to run Vault agent as. Defaults to %d.", agent.DefaultAgentRunAsUser))
 	c.flagSet.StringVar(&c.flagRunAsGroup, "run-as-group", strconv.Itoa(agent.DefaultAgentRunAsGroup),
@@ -347,6 +352,13 @@ func (c *Command) parseEnvs() error {
 
 	if envs.RevokeOnShutdown != "" {
 		c.flagRevokeOnShutdown, err = parseutil.ParseBool(envs.RevokeOnShutdown)
+		if err != nil {
+			return err
+		}
+	}
+
+	if envs.ExitAfterAuth != "" {
+		c.flagExitAfterAuth, err = parseutil.ParseBool(envs.ExitAfterAuth)
 		if err != nil {
 			return err
 		}

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -172,6 +172,8 @@ func TestCommandEnvBools(t *testing.T) {
 	}{
 		{env: "AGENT_INJECT_REVOKE_ON_SHUTDOWN", value: true, cmdPtr: &cmd.flagRevokeOnShutdown},
 		{env: "AGENT_INJECT_REVOKE_ON_SHUTDOWN", value: false, cmdPtr: &cmd.flagRevokeOnShutdown},
+		{env: "AGENT_INJECT_EXIT_AFTER_AUTH", value: true, cmdPtr: &cmd.flagExitAfterAuth},
+		{env: "AGENT_INJECT_EXIT_AFTER_AUTH", value: false, cmdPtr: &cmd.flagExitAfterAuth},
 		{env: "AGENT_INJECT_RUN_AS_SAME_USER", value: true, cmdPtr: &cmd.flagRunAsSameUser},
 		{env: "AGENT_INJECT_RUN_AS_SAME_USER", value: false, cmdPtr: &cmd.flagRunAsSameUser},
 		{env: "AGENT_INJECT_SET_SECURITY_CONTEXT", value: true, cmdPtr: &cmd.flagSetSecurityContext},


### PR DESCRIPTION
Fixes [#724](https://github.com/hashicorp/vault-k8s/issues/724) by adding `vault.hashicorp.com/agent-exit-after-auth`

To tell the agent to exit after auth, set annotation to true:
`vault.hashicorp.com/agent-exit-after-auth: "true"`

