### PR TITLE
Update webhook CA bundle verification log message

### DIFF
--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -378,7 +378,7 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.Bundle, client
 
 		case <-webhooksWatcher:
 			// Webhooks changed, make sure the CA bundle is up-to-date.
-			log.Info("Webhooks changed. Updating certs...")
+			log.Trace("Checking to ensure CA bundle is up-to-date...")
 
 		case <-ctx.Done():
 			// Quit

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -378,7 +378,7 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.Bundle, client
 
 		case <-webhooksWatcher:
 			// Webhooks changed, make sure the CA bundle is up-to-date.
-			log.Trace("Checking to ensure CA bundle is up-to-date...")
+			log.Debug("Checking to ensure CA bundle is up-to-date...")
 
 		case <-ctx.Done():
 			// Quit


### PR DESCRIPTION
Makes log message more accurate by clarifying that this step verifies the existing CA bundle configuration rather than suggesting certificate regeneration.

Changes:
- Adjusted log level from Info to Debug
- Updated message to better reflect the actual operation