### PR TITLE
move Red Hat image to newest UBI release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENTRYPOINT ["/bin/vault-k8s"]
 
 # This target creates a production ubi release image
 # for the project for use on OpenShift.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179 AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367 AS ubi
 
 ARG PRODUCT_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
There was a new Red Hat UBI released today that addresses several medium-rated CVEs. Unlikely to be exposed in vault-k8s context, but bumping to avoid vulnerability scan noise.

https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?image=67ab720ff6625fa4004d12b6

