### PR TITLE
Preparing v1.6.2 release

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -59,7 +59,7 @@ runs:
         cluster_name: ${{ inputs.kind-cluster-name }}
         config: vault-helm/test/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
-        version: "v0.26.0"
+        version: "v0.27.0"
 
     - name: Create kind export log root
       id: create_kind_export_log_root

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,8 +39,8 @@ jobs:
       - run: echo "setting versions"
     outputs:
       # JSON encoded array of k8s versions.
-      K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.15", "1.27.16"]'
-      VAULT_N: "1.18.2"
+      K8S_VERSIONS: '["1.32.2", "1.31.6", "1.30.10", "1.29.14", "1.28.15"]'
+      VAULT_N: "1.18.5"
       VAULT_N_1: "1.17.6"
       VAULT_N_2: "1.16.3"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,38 @@
 ## Unreleased
 
+## 1.6.2 (February 26, 2025)
+
 Changes:
 * Building with Go 1.23.6
+* Default Vault version updated to 1.18.5
+* Testing with K8s versions 1.28 - 1.32
 * Dependency updates:
+  * Docker image `alpine` 3.21.0 => 3.21.3
+  * Docker image `ubi8/ubi-minimal` 8.10-1130 => 8.10-1179.1739286367
+  * github.com/evanphx/json-patch v5.9.0+incompatible => v5.9.11+incompatible
+  * github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 => v0.1.9
+  * github.com/hashicorp/vault/sdk v0.14.0 => v0.15.0
+  * github.com/operator-framework/operator-lib v0.15.0 => v0.17.0
   * golang.org/x/crypto v0.31.0 => v0.35.0
-  * golang.org/x/oauth2 v0.24.0 => v0.27.0
   * golang.org/x/net v0.32.0 => v0.35.0
+  * golang.org/x/oauth2 v0.21.0 => v0.27.0
   * golang.org/x/sys v0.28.0 => v0.30.0
   * golang.org/x/term v0.27.0 => v0.29.0
   * golang.org/x/text v0.21.0 => v0.22.0
-  * k8s.io/apimachinery v0.31.3 => v0.32.0
-  * k8s.io/client-go v0.31.3 => v0.32.0
+  * k8s.io/api v0.31.3 => v0.32.2
+  * k8s.io/apimachinery v0.31.3 => v0.32.2
+  * k8s.io/client-go v0.31.3 => v0.32.2
   * k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 => v0.0.0-20241104100929-3ea5e8cea738
-  * sigs.k8s.io/controller-runtime v0.19.2 => v0.19.3
+  * sigs.k8s.io/controller-runtime v0.19.2 => v0.20.2
+
+Bugs:
+* Update webhook CA bundle verification log message [GH-739](https://github.com/hashicorp/vault-k8s/pull/739)
 
 ## 1.6.1 (December 16, 2024)
 
 Changes:
 * Dependency updates:
   * Docker image `alpine` 3.20.3 => 3.21.0
-  * Docker image `ubi8/ubi-minimal` 8.10-1130 => 8.10-1154
   * golang.org/x/crypto v0.30.0 => v0.31.0
 
 Bugs:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY_NAME ?= docker.io/hashicorp
 IMAGE_NAME = vault-k8s
 VERSION ?= 0.0.0-dev
-VAULT_VERSION ?= 1.18.2
+VAULT_VERSION ?= 1.18.5
 IMAGE_TAG ?= $(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
 PUBLISH_LOCATION ?= https://releases.hashicorp.com
 DOCKER_DIR = ./build/docker

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DefaultVaultImage                       = "hashicorp/vault:1.18.2"
+	DefaultVaultImage                       = "hashicorp/vault:1.18.5"
 	DefaultVaultAuthType                    = "kubernetes"
 	DefaultVaultAuthPath                    = "auth/kubernetes"
 	DefaultAgentRunAsUser                   = 100

--- a/deploy/injector-deployment.yaml
+++ b/deploy/injector-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: "vault-injector"
       containers:
         - name: sidecar-injector
-          image: "hashicorp/vault-k8s:1.6.0"
+          image: "hashicorp/vault-k8s:1.6.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE
@@ -44,7 +44,7 @@ spec:
             - name: AGENT_INJECT_VAULT_ADDR
               value: "https://vault.$(NAMESPACE).svc:8200"
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "hashicorp/vault:1.18.2"
+              value: "hashicorp/vault:1.18.5"
             - name: AGENT_INJECT_TLS_AUTO
               value: vault-agent-injector-cfg
             - name: AGENT_INJECT_TLS_AUTO_HOSTS

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -119,7 +119,7 @@ func TestCommandEnvs(t *testing.T) {
 		{env: "AGENT_INJECT_VAULT_CACERT_BYTES", value: "foo", cmdPtr: &cmd.flagVaultCACertBytes},
 		{env: "AGENT_INJECT_PROXY_ADDR", value: "http://proxy:3128", cmdPtr: &cmd.flagProxyAddress},
 		{env: "AGENT_INJECT_VAULT_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagVaultAuthPath},
-		{env: "AGENT_INJECT_VAULT_IMAGE", value: "hashicorp/vault:1.18.2", cmdPtr: &cmd.flagVaultImage},
+		{env: "AGENT_INJECT_VAULT_IMAGE", value: "hashicorp/vault:1.18.5", cmdPtr: &cmd.flagVaultImage},
 		{env: "AGENT_INJECT_VAULT_NAMESPACE", value: "test-namespace", cmdPtr: &cmd.flagVaultNamespace},
 		{env: "AGENT_INJECT_TLS_KEY_FILE", value: "server.key", cmdPtr: &cmd.flagKeyFile},
 		{env: "AGENT_INJECT_TLS_CERT_FILE", value: "server.crt", cmdPtr: &cmd.flagCertFile},


### PR DESCRIPTION
Updating kind, k8s versions, Vault version, and changelog.

(Previous release PR for comparison: https://github.com/hashicorp/vault-k8s/pull/719)

<!-- VAULT-34316 -->