### PR TITLE
Add `template_config.lease_renewal_threshold` option to Agent Injector annotations

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -355,6 +355,11 @@ type VaultAgentTemplateConfig struct {
 	//  that the Vault Agent templating engine can use for a particular Vault host. This limit
 	//  includes connections in the dialing, active, and idle states.
 	MaxConnectionsPerHost int64
+
+	// LeaseRenewalThreshold How long Vault Agent's template engine should wait
+	// for to refresh dynamic, non-renewable leases, measured as a fraction of
+	// the lease duration.
+	LeaseRenewalThreshold float64
 }
 
 // New creates a new instance of Agent by parsing all the Kubernetes annotations.
@@ -526,10 +531,16 @@ func New(pod *corev1.Pod) (*Agent, error) {
 		return nil, err
 	}
 
+	leaseRenewalThreshold, err := agent.templateConfigLeaseRenewalThreshold()
+	if err != nil {
+		return nil, err
+	}
+
 	agent.VaultAgentTemplateConfig = VaultAgentTemplateConfig{
 		ExitOnRetryFailure:         exitOnRetryFailure,
 		StaticSecretRenderInterval: pod.Annotations[AnnotationTemplateConfigStaticSecretRenderInterval],
 		MaxConnectionsPerHost:      maxConnectionsPerHost,
+		LeaseRenewalThreshold:      leaseRenewalThreshold,
 	}
 
 	agent.EnableQuit, err = agent.getEnableQuit()

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -295,6 +295,11 @@ const (
 	//  includes connections in the dialing, active, and idle states.
 	AnnotationTemplateConfigMaxConnectionsPerHost = "vault.hashicorp.com/template-max-connections-per-host"
 
+	// AnnotationTemplateConfigLeaseRenewalThreshold
+	// How long Vault Agent's template engine should wait for to refresh dynamic,
+	// non-renewable leases, measured as a fraction of the lease duration.
+	AnnotationTemplateConfigLeaseRenewalThreshold = "vault.hashicorp.com/template-lease-renewal-threshold"
+
 	// AnnotationAgentEnableQuit configures whether the quit endpoint is
 	// enabled in the injected agent config
 	AnnotationAgentEnableQuit = "vault.hashicorp.com/agent-enable-quit"
@@ -365,6 +370,7 @@ type AgentConfig struct {
 	ExitOnRetryFailure         bool
 	StaticSecretRenderInterval string
 	MaxConnectionsPerHost      int64
+	LeaseRenewalThreshold      float64
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
 	DisableIdleConnections     string
@@ -551,6 +557,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigMaxConnectionsPerHost]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationTemplateConfigMaxConnectionsPerHost] = strconv.FormatInt(cfg.MaxConnectionsPerHost, 10)
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigLeaseRenewalThreshold]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationTemplateConfigLeaseRenewalThreshold] = strconv.FormatFloat(cfg.LeaseRenewalThreshold, 'f', -1, 64)
 	}
 
 	if minBackoffString, ok := pod.ObjectMeta.Annotations[AnnotationAgentAuthMinBackoff]; ok {
@@ -863,6 +873,15 @@ func (a *Agent) templateConfigMaxConnectionsPerHost() (int64, error) {
 	}
 
 	return parseutil.ParseInt(raw)
+}
+
+func (a *Agent) templateConfigLeaseRenewalThreshold() (float64, error) {
+	raw, ok := a.Annotations[AnnotationTemplateConfigLeaseRenewalThreshold]
+	if !ok {
+		return 0, nil
+	}
+
+	return strconv.ParseFloat(raw, 64)
 }
 
 func (a *Agent) getAutoAuthExitOnError() (bool, error) {

--- a/agent-inject/agent/config.go
+++ b/agent-inject/agent/config.go
@@ -122,9 +122,10 @@ type CachePersist struct {
 
 // TemplateConfig defines the configuration for template_config in Vault Agent
 type TemplateConfig struct {
-	ExitOnRetryFailure         bool   `json:"exit_on_retry_failure"`
-	StaticSecretRenderInterval string `json:"static_secret_render_interval,omitempty"`
-	MaxConnectionsPerHost      int64  `json:"max_connections_per_host,omitempty"`
+	ExitOnRetryFailure         bool     `json:"exit_on_retry_failure"`
+	StaticSecretRenderInterval string   `json:"static_secret_render_interval,omitempty"`
+	MaxConnectionsPerHost      int64    `json:"max_connections_per_host,omitempty"`
+	LeaseRenewalThreshold      float64  `json:"lease_renewal_threshold,omitempty"`
 }
 
 // Telemetry defines the configuration for agent telemetry in Vault Agent.
@@ -267,6 +268,7 @@ func (a *Agent) newConfig(init bool) ([]byte, error) {
 			ExitOnRetryFailure:         a.VaultAgentTemplateConfig.ExitOnRetryFailure,
 			StaticSecretRenderInterval: a.VaultAgentTemplateConfig.StaticSecretRenderInterval,
 			MaxConnectionsPerHost:      a.VaultAgentTemplateConfig.MaxConnectionsPerHost,
+			LeaseRenewalThreshold:      a.VaultAgentTemplateConfig.LeaseRenewalThreshold,
 		},
 		DisableIdleConnections: a.DisableIdleConnections,
 		DisableKeepAlives:      a.DisableKeepAlives,

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -676,6 +676,17 @@ func TestConfigVaultAgentTemplateConfig(t *testing.T) {
 			},
 		},
 		{
+			"lease_renewal_threshold 0.75",
+			map[string]string{
+				AnnotationTemplateConfigLeaseRenewalThreshold: "0.75",
+			},
+			&TemplateConfig{
+				ExitOnRetryFailure:    true,
+				MaxConnectionsPerHost: 0,
+				LeaseRenewalThreshold: 0.75,
+			},
+		},
+		{
 			"template_config_empty",
 			map[string]string{},
 			&TemplateConfig{

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -74,6 +74,7 @@ type Handler struct {
 	ExitOnRetryFailure         bool
 	StaticSecretRenderInterval string
 	MaxConnectionsPerHost      int64
+	LeaseRenewalThreshold      float64
 	AuthMinBackoff             string
 	AuthMaxBackoff             string
 	DisableIdleConnections     string
@@ -244,6 +245,7 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) MutateResponse {
 		ExitOnRetryFailure:         h.ExitOnRetryFailure,
 		StaticSecretRenderInterval: h.StaticSecretRenderInterval,
 		MaxConnectionsPerHost:      h.MaxConnectionsPerHost,
+		LeaseRenewalThreshold:      h.LeaseRenewalThreshold,
 		AuthMinBackoff:             h.AuthMinBackoff,
 		AuthMaxBackoff:             h.AuthMaxBackoff,
 		DisableIdleConnections:     h.DisableIdleConnections,

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -45,44 +45,45 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flagListen                     string // Address of Vault Server
-	flagLogLevel                   string // Log verbosity
-	flagLogFormat                  string // Log format
-	flagCACertFile                 string // TLS CA Certificate to serve
-	flagCertFile                   string // TLS Certificate to serve
-	flagKeyFile                    string // TLS private key to serve
-	flagExitOnRetryFailure         bool   // Set template_config.exit_on_retry_failure on agent
-	flagStaticSecretRenderInterval string // Set template_config.static_secret_render_interval on agent
-	flagMaxConnectionsPerHost      int64  // Set template_config.max_connections_per_host on agent
-	flagAutoName                   string // MutatingWebhookConfiguration for updating
-	flagAutoHosts                  string // SANs for the auto-generated TLS cert.
-	flagVaultService               string // Name of the Vault service
-	flagVaultCACertBytes           string // CA Cert to trust for TLS with Vault.
-	flagProxyAddress               string // HTTP proxy address used to talk to the Vault service
-	flagVaultImage                 string // Name of the Vault Image to use
-	flagVaultAuthType              string // Type of Vault Auth Method to use
-	flagVaultAuthPath              string // Mount path of the Vault Auth Method
-	flagVaultNamespace             string // Vault enterprise namespace
-	flagRevokeOnShutdown           bool   // Revoke Vault Token on pod shutdown
-	flagRunAsUser                  string // User (uid) to run Vault agent as
-	flagRunAsGroup                 string // Group (gid) to run Vault agent as
-	flagRunAsSameUser              bool   // Run Vault agent as the User (uid) of the first application container
-	flagSetSecurityContext         bool   // Set SecurityContext in injected containers
-	flagTelemetryPath              string // Path under which to expose metrics
-	flagUseLeaderElector           bool   // Use leader elector code
-	flagDefaultTemplate            string // Toggles which default template to use
-	flagResourceRequestCPU         string // Set CPU request in the injected containers
-	flagResourceRequestMem         string // Set Memory request in the injected containers
-	flagResourceRequestEphemeral   string // Set Ephemeral Storage request in the injected containers
-	flagResourceLimitCPU           string // Set CPU limit in the injected containers
-	flagResourceLimitMem           string // Set Memory limit in the injected containers
-	flagResourceLimitEphemeral     string // Set Ephemeral storage limit in the injected containers
-	flagTLSMinVersion              string // Minimum TLS version supported by the webhook server
-	flagTLSCipherSuites            string // Comma-separated list of supported cipher suites
-	flagAuthMinBackoff             string // Auth min backoff on failure
-	flagAuthMaxBackoff             string // Auth min backoff on failure
-	flagDisableIdleConnections     string // Idle connections control
-	flagDisableKeepAlives          string // Keep-alives control
+	flagListen                     string   // Address of Vault Server
+	flagLogLevel                   string   // Log verbosity
+	flagLogFormat                  string   // Log format
+	flagCACertFile                 string   // TLS CA Certificate to serve
+	flagCertFile                   string   // TLS Certificate to serve
+	flagKeyFile                    string   // TLS private key to serve
+	flagExitOnRetryFailure         bool     // Set template_config.exit_on_retry_failure on agent
+	flagStaticSecretRenderInterval string   // Set template_config.static_secret_render_interval on agent
+	flagMaxConnectionsPerHost      int64    // Set template_config.max_connections_per_host on agent
+	flagLeaseRenewalThreshold      float64  // Set template_config.max_connections_per_host on agent
+	flagAutoName                   string   // MutatingWebhookConfiguration for updating
+	flagAutoHosts                  string   // SANs for the auto-generated TLS cert.
+	flagVaultService               string   // Name of the Vault service
+	flagVaultCACertBytes           string   // CA Cert to trust for TLS with Vault.
+	flagProxyAddress               string   // HTTP proxy address used to talk to the Vault service
+	flagVaultImage                 string   // Name of the Vault Image to use
+	flagVaultAuthType              string   // Type of Vault Auth Method to use
+	flagVaultAuthPath              string   // Mount path of the Vault Auth Method
+	flagVaultNamespace             string   // Vault enterprise namespace
+	flagRevokeOnShutdown           bool     // Revoke Vault Token on pod shutdown
+	flagRunAsUser                  string   // User (uid) to run Vault agent as
+	flagRunAsGroup                 string   // Group (gid) to run Vault agent as
+	flagRunAsSameUser              bool     // Run Vault agent as the User (uid) of the first application container
+	flagSetSecurityContext         bool     // Set SecurityContext in injected containers
+	flagTelemetryPath              string   // Path under which to expose metrics
+	flagUseLeaderElector           bool     // Use leader elector code
+	flagDefaultTemplate            string   // Toggles which default template to use
+	flagResourceRequestCPU         string   // Set CPU request in the injected containers
+	flagResourceRequestMem         string   // Set Memory request in the injected containers
+	flagResourceRequestEphemeral   string   // Set Ephemeral Storage request in the injected containers
+	flagResourceLimitCPU           string   // Set CPU limit in the injected containers
+	flagResourceLimitMem           string   // Set Memory limit in the injected containers
+	flagResourceLimitEphemeral     string   // Set Ephemeral storage limit in the injected containers
+	flagTLSMinVersion              string   // Minimum TLS version supported by the webhook server
+	flagTLSCipherSuites            string   // Comma-separated list of supported cipher suites
+	flagAuthMinBackoff             string   // Auth min backoff on failure
+	flagAuthMaxBackoff             string   // Auth min backoff on failure
+	flagDisableIdleConnections     string   // Idle connections control
+	flagDisableKeepAlives          string   // Keep-alives control
 
 	flagSet *flag.FlagSet
 
@@ -222,6 +223,7 @@ func (c *Command) Run(args []string) int {
 		ExitOnRetryFailure:         c.flagExitOnRetryFailure,
 		StaticSecretRenderInterval: c.flagStaticSecretRenderInterval,
 		MaxConnectionsPerHost:      c.flagMaxConnectionsPerHost,
+		LeaseRenewalThreshold:      c.flagLeaseRenewalThreshold,
 		AuthMinBackoff:             c.flagAuthMinBackoff,
 		AuthMaxBackoff:             c.flagAuthMaxBackoff,
 		DisableIdleConnections:     c.flagDisableIdleConnections,

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -50,6 +50,10 @@ type Specification struct {
 	// AGENT_INJECT_TEMPLATE_MAX_CONNECTIONS_PER_HOST environment variable.
 	TemplateConfigMaxConnectionsPerHost string `envconfig:"AGENT_INJECT_TEMPLATE_MAX_CONNECTIONS_PER_HOST"`
 
+	// TemplateConfigLeaseRenewalThreshold is the
+	// AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD environment variable.
+	TemplateConfigLeaseRenewalThreshold string `envconfig:"AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD"'
+
 	// TLSAuto is the AGENT_INJECT_TLS_AUTO environment variable.
 	TLSAuto string `envconfig:"tls_auto"`
 
@@ -293,6 +297,13 @@ func (c *Command) parseEnvs() error {
 
 	if envs.TemplateConfigMaxConnectionsPerHost != "" {
 		c.flagMaxConnectionsPerHost, err = parseutil.ParseInt(envs.TemplateConfigMaxConnectionsPerHost)
+		if err != nil {
+			return err
+		}
+	}
+
+	if envs.TemplateConfigLeaseRenewalThreshold != "" {
+		c.flagLeaseRenewalThreshold, err = strconv.ParseFloat(envs.TemplateConfigLeaseRenewalThreshold, 64)
 		if err != nil {
 			return err
 		}

--- a/subcommand/injector/flags.go
+++ b/subcommand/injector/flags.go
@@ -52,7 +52,7 @@ type Specification struct {
 
 	// TemplateConfigLeaseRenewalThreshold is the
 	// AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD environment variable.
-	TemplateConfigLeaseRenewalThreshold string `envconfig:"AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD"'
+	TemplateConfigLeaseRenewalThreshold string `envconfig:"AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD"`
 
 	// TLSAuto is the AGENT_INJECT_TLS_AUTO environment variable.
 	TLSAuto string `envconfig:"tls_auto"`

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -227,3 +227,31 @@ func TestCommandEnvInts(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandEnvFloats(t *testing.T) {
+	var cmd Command
+	tests := []struct {
+		env    string
+		value  float64
+		cmdPtr *float64
+	}{
+		{env: "AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD", value: 0.75, cmdPtr: &cmd.flagLeaseRenewalThreshold},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			if err := os.Setenv(tt.env, strconv.FormatFloat(tt.value, 'f', -1, 64)); err != nil {
+				t.Errorf("got error setting env, shouldn't have: %s", err)
+			}
+			defer os.Unsetenv(tt.env)
+
+			if err := cmd.parseEnvs(); err != nil {
+				t.Errorf("got error parsing envs, shouldn't have: %s", err)
+			}
+
+			if *tt.cmdPtr != tt.value {
+				t.Errorf("env wasn't parsed, should have been: got %f, expected %f", *tt.cmdPtr, tt.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the missing Vault Agent `template_config` option to vault-k8s so `lease_renewal_threshold` can be set directly via `vault.hashicorp.com/template-lease-renewal-threshold` annotation.  Currently, the only way to set this option on injected Vault agents is to write an entire config with the parameter set, and mount it in a ConfigMap.