### PR TITLE
updating changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes:
   * sigs.k8s.io/controller-runtime v0.20.2 => v0.21.0
 
 Features:
-* Add support for setting `template_config.lease_duration_threshold` in Agent config [GH-761](https://github.com/hashicorp/vault-k8s/pull/761)
+* Add support for setting `template_config.lease_renewal_threshold` in Agent config [GH-761](https://github.com/hashicorp/vault-k8s/pull/761)
 
 ## 1.6.2 (February 26, 2025)
 


### PR DESCRIPTION
https://github.com/hashicorp/vault-k8s/pull/761 listed the Vault Agent template option as `lease_duration_threshold` instead of [`lease_renewal_threshold`](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent/template#lease_renewal_threshold) in the title and description. The PR has since been updated, so this is updating the changelog to match.