### PR TITLE
Fix lease duration env var in agent-injector config

### DIFF
--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -591,6 +591,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 		pod.ObjectMeta.Annotations[AnnotationAgentDisableKeepAlives] = cfg.DisableKeepAlives
 	}
 
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationTemplateConfigLeaseRenewalThreshold]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationTemplateConfigLeaseRenewalThreshold] = strconv.FormatFloat(cfg.LeaseRenewalThreshold, 'f', -1, 64)
+	}
+
 	// validate JSON patches
 	if patch, ok := pod.ObjectMeta.Annotations[AnnotationAgentJsonPatch]; ok {
 		// ignore empty string


### PR DESCRIPTION
When setting the environment variable `AGENT_INJECT_TEMPLATE_LEASE_RENEWAL_THRESHOLD` on the agent-injector pods to configure when a lease should be renewed, `template_config.lease_renewal_threshold` was not being set in the injected vault config:

```json
{
  "auto_auth": {
    "method": {
      "type": "kubernetes",
      "mount_path": "auth/kubernetes/cluster-01",
      "config": {
        "role": "test_vault-test_vault",
        "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"
      }
    },
    "sink": [
      {
        "type": "file",
        "config": {
          "path": "/home/vault/.vault-token"
        }
      }
    ]
  },
  "exit_after_auth": false,
  "pid_file": "/home/vault/.pid",
  "vault": {
    "address": "<redacted>"
  },
  "template": [
    {
      "destination": "/config/mycreds",
      "contents": "{{ with secret \"db/test/creds/readonly\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}",
      "left_delimiter": "{{",
      "right_delimiter": "}}"
    }
  ],
  "template_config": {
    "exit_on_retry_failure": true
  }
}
```

I believe it is missing from `Agent.Init()` and this fixes the generated vault config for me locally:
```json
{
  "auto_auth": {
    "method": {
      "type": "kubernetes",
      "mount_path": "auth/kubernetes/cluster-01",
      "config": {
        "role": "test_vault-test_vault",
        "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token"
      }
    },
    "sink": [
      {
        "type": "file",
        "config": {
          "path": "/home/vault/.vault-token"
        }
      }
    ]
  },
  "exit_after_auth": false,
  "pid_file": "/home/vault/.pid",
  "vault": {
    "address": "<redacted>"
  },
  "template": [
    {
      "destination": "/config/mycreds",
      "contents": "{{ with secret \"db/test/creds/readonly\" }}{{ range $k, $v := .Data }}{{ $k }}: {{ $v }}\n{{ end }}{{ end }}",
      "left_delimiter": "{{",
      "right_delimiter": "}}"
    }
  ],
  "template_config": {
    "exit_on_retry_failure": true,
    "lease_renewal_threshold": 0.08
  }
}
```