### PR TITLE
fix: option to disable base env var injection

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -188,6 +188,9 @@ type Agent struct {
 
 	// AutoAuthExitOnError is used to control if a failure in the auto_auth method will cause the agent to exit or try indefinitely (the default).
 	AutoAuthExitOnError bool
+
+	// NoBaseEnvVars controls whether the agent will inject the basic environment variables NAMESPACE, HOST_IP and POD_IP.
+	NoBaseEnvVars bool
 }
 
 type ServiceAccountTokenVolume struct {
@@ -373,6 +376,11 @@ func New(pod *corev1.Pod) (*Agent, error) {
 		iamName, iamPath = getAwsIamTokenVolume(pod)
 	}
 
+	noBaseEnvVars := false
+	if pod.Annotations[AnnotationAgentNoBaseEnvVars] == "true" {
+		noBaseEnvVars = true
+	}
+
 	agent := &Agent{
 		Annotations:               pod.Annotations,
 		ConfigMapName:             pod.Annotations[AnnotationAgentConfigMap],
@@ -395,6 +403,7 @@ func New(pod *corev1.Pod) (*Agent, error) {
 		AwsIamTokenAccountPath:    iamPath,
 		JsonPatch:                 pod.Annotations[AnnotationAgentJsonPatch],
 		InitJsonPatch:             pod.Annotations[AnnotationAgentInitJsonPatch],
+		NoBaseEnvVars:             noBaseEnvVars,
 		Vault: Vault{
 			Address:          pod.Annotations[AnnotationVaultService],
 			ProxyAddress:     pod.Annotations[AnnotationProxyAddress],

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -344,6 +344,10 @@ const (
 	// should map to the same unique value provided in
 	// "vault.hashicorp.com/agent-inject-secret-". Defaults to false
 	AnnotationErrorOnMissingKey = "vault.hashicorp.com/error-on-missing-key"
+
+	// AnnotationAgentNoBaseEnvVars configures whether the agent will inject
+	// the basic environment variables NAMESPACE, HOST_IP and POD_IP.
+	AnnotationAgentNoBaseEnvVars = "vault.hashicorp.com/agent-no-base-env-vars"
 )
 
 type AgentConfig struct {

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -40,7 +40,10 @@ var baseContainerEnvVars []corev1.EnvVar = []corev1.EnvVar{
 // ContainerEnvVars adds the applicable environment vars
 // for the Vault Agent sidecar.
 func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
-	envs := baseContainerEnvVars
+	var envs []corev1.EnvVar
+	if !a.NoBaseEnvVars {
+		envs = baseContainerEnvVars
+	}
 
 	if a.Vault.GoMaxProcs != "" {
 		envs = append(envs, corev1.EnvVar{


### PR DESCRIPTION
Fixes #734 

#486 introduced the environment variables `NAMESPACE`, `HOST_IP` and `POD_IP` which are not needed in the code (as I checked it) and are only there as "nice to have".

In newly created clusters where the cloud controller manager is not running (because the agent injector should be used to inject secrets into the cloud controller manager) the nodes do not have a host ip address set. So the pods cannot start because of the error `Error: host IP unknown;`.

This PR adds the ability to disable the injection of these basic env vars with a new annotation called `vault.hashicorp.com/agent-no-base-env-vars=true`.

I hope I did all relevant code changes, I am new to this project.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
