### PR TITLE
Support running the sidecar injector alongside EKS Pod Identities

### DIFF
--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -564,6 +564,49 @@ func Test_serviceaccount(t *testing.T) {
 				},
 			},
 		},
+		"projected service account with pattern annotation": {
+			expected: &ServiceAccountTokenVolume{
+				Name:      "kube-api-access-cfjv5",
+				MountPath: "/var/run/secrets/special/serviceaccount",
+				TokenPath: "vault-token",
+			},
+			expectedError: "",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"vault.hashicorp.com/agent-service-account-token-volume-name-pattern": "kube-api-access-*",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "kube-api-access-cfjv5",
+									MountPath: "/var/run/secrets/special/serviceaccount",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "kube-api-access-cfjv5",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+												Path: "vault-token",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -184,6 +184,10 @@ const (
 	// and gid) is set on the injected Vault Agent containers
 	AnnotationAgentSetSecurityContext = "vault.hashicorp.com/agent-set-security-context"
 
+	// AnnotationAgentServiceAccountTokenVolumeNamePattern is the optional name pattern of a volume containing a
+	// service account token
+	AnnotationAgentServiceAccountTokenVolumeNamePattern = "vault.hashicorp.com/agent-service-account-token-volume-name-pattern"
+
 	// AnnotationAgentServiceAccountTokenVolumeName is the optional name of a volume containing a
 	// service account token
 	AnnotationAgentServiceAccountTokenVolumeName = "vault.hashicorp.com/agent-service-account-token-volume-name"
@@ -482,6 +486,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationVaultLogFormat]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationVaultLogFormat] = DefaultAgentLogFormat
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeNamePattern]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeNamePattern] = ""
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeName]; !ok {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-logr/logr v1.4.3
+	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


We're running into an issue when using the Vault sidecar injector alongside EKS Pod Identities. Given a container in a pod with the following volumeMounts:
```
volumeMounts:
  - mountPath: /var/run/secrets/pods.eks.amazonaws.com/serviceaccount
    name: eks-pod-identity-token
    readOnly: true
  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    name: kube-api-access-cfjv5
    readOnly: true
```

The `serviceaccount` function (https://github.com/hashicorp/vault-k8s/blob/main/agent-inject/agent/agent.go#L778) by default looks for any volumemount where the mountPath contains `serviceAccount`, and in this scenario means that the vault sidecar injector picks the `eks-pod-identity-token` volume mount when building the `VAULT_CONFIG` environment var that gets injected into the pod/containers, which results in:
```
a lot of config below has been ommited for brevity
{
  "auto_auth": {
    "method": {
      "config": {
        "role": "...",
        "token_path": "/var/run/secrets/pods.eks.amazonaws.com/serviceaccount/token"
      }
    },
  },
}
```

So when the `vault-agent-init` container starts up we get the below logs:

```
2025-10-13T11:51:36.002Z [ERROR] agent.auth.handler: error getting path or data from method: error="error reading JWT with Kubernetes Auth: open /var/run/secrets/pods.eks.amazonaws.com/serviceaccount/token: no such file or directory" backoff=4m48.51s
```

as the container is using the wrong path to load the SA token from which is used to authenticate with Vault.


In this PR I've added a new annotation `vault.hashicorp.com/agent-service-account-token-volume-name-pattern`. Similar to the existing `vault.hashicorp.com/agent-service-account-token-volume-name` pattern but it allows us to pattern/glob match the volume name that contains the projected SA token. Since v1.22 Kubernetes has automatically added  (enabled by default) a projected volume to all pods named `kube-api-access-<random-suffix>` which contains the SA token, ca cert and namespace. This change allows us to use this volume in conjunction with EKS Pod Identities by setting:
```
metadata:
  annotations:
    vault.hashicorp.com/agent-service-account-token-volume-name-pattern: "kube-api-access*"
```
which will assist the sidecar injector in selecting the correct volume containing the SA token




