### PR TITLE
ci: declare permissions on build, jira, tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
 env:
   PKG_NAME: "vault-k8s"
 
+permissions:
+  contents: read
+
 jobs:
   get-product-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -6,6 +6,13 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
+
+# Reusable Jira sync only reads issue/PR metadata to mirror to Jira.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   sync:
     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,9 @@ name: Tests
 # Run this workflow on pushes and manually
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     env:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the three CI workflows currently inheriting org defaults:

| Workflow | Scope | Why |
|----------|-------|-----|
| `build.yml` | `contents: read` | full build/docker pipeline; image push goes through `hashicorp/actions-docker-build` (its own docker registry secrets), artifacts via `actions/upload-artifact` |
| `jira.yaml` | `contents: read` + `issues: read` + `pull-requests: read` | caller for `hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main`; Jira writes use `JIRA_SYNC_API_TOKEN` |
| `tests.yaml` | `contents: read` | go test + kind-based integration tests; no GitHub API writes |

YAML validated locally.