### PR TITLE
Add support for linux/ppc64le (UBI only)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm", "arm64", "386", "amd64", "s390x"]
+        arch: ["arm", "arm64", "386", "amd64", "s390x", "ppc64le"]
       fail-fast: true
 
     name: Go linux ${{ matrix.arch }} build
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["amd64", "arm64", "s390x"]
+        arch: ["amd64", "arm64", "s390x", "ppc64le"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -129,8 +129,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x images can only ever be published the Red Hat catalog and ICR.
-        if: ${{ matrix.arch != 's390x'}}
+        # linux/s390x and linux/ppc64le images can only ever be published to the Red Hat catalog and ICR.
+        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le'}}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -142,8 +142,8 @@ jobs:
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.version}}-ubi
 
       - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x images are published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch == 's390x'}}
+        # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR.
+        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le'}}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["amd64", "arm64", "s390x", "ppc64le"]
+        arch: ["amd64", "arm64"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -129,8 +129,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x and linux/ppc64le images can only ever be published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le'}}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -141,9 +139,22 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}-ubi
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.version}}-ubi
 
-      - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le'}}
+  build-docker-ubi-ibm:
+    name: UBI IBM ${{ matrix.arch }} build
+    needs:
+      - get-product-version
+      - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["s390x", "ppc64le"]
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
 
-  build-docker-ubi-redhat:
+  build-docker-ubi:
     name: Docker Build UBI Image for RedHat Registry
     needs:
       - get-product-version

--- a/.release/vault-k8s-artifacts.hcl
+++ b/.release/vault-k8s-artifacts.hcl
@@ -9,6 +9,7 @@ artifacts {
     "vault-k8s_${version}_linux_arm.zip",
     "vault-k8s_${version}_linux_arm64.zip",
     "vault-k8s_${version}_linux_s390x.zip",
+    "vault-k8s_${version}_linux_ppc64le.zip",
   ]
   container = [
     "vault-k8s_default_linux_386_${version}_${commit_sha}.docker.tar",
@@ -22,5 +23,8 @@ artifacts {
     # s390x is published to the Red Hat catalog and ICR
     "vault-k8s_ubi_linux_s390x_${version}_${commit_sha}.docker.redhat.tar",
     "vault-k8s_ubi_linux_s390x_${version}_${commit_sha}.docker.tar",
+    # ppc64le is published to the Red Hat catalog and ICR
+    "vault-k8s_ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar",
+    "vault-k8s_ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Changes:
+* Build linux/ppc64le UBI images and publish to ICR and Red Hat catalog
+
 ## 1.7.5 (June 29, 2026)
 
 Changes:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ build: clean
 		.
 
 image: build
+	# --load required for Podman/buildx: exports image into local daemon store
 	docker build --load --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
 
 # Deploys Vault dev server and a locally built Agent Injector.

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build: clean
 		.
 
 image: build
-	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
+	docker build --load --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
 
 # Deploys Vault dev server and a locally built Agent Injector.
 # Run multiple times to deploy new builds of the injector.


### PR DESCRIPTION
## Description

Adds `ppc64le` (IBM Power) architecture support to the vault-k8s build and
release pipeline. This enables vault-k8s images to be built, pushed, and
distributed for `ppc64le` environments alongside the existing `amd64`, `arm64`,
and `s390x` architectures.

## Changes

### `.github/workflows/build.yml`
- `ppc64le` was already included in the binary build matrix (`build` job).
- Refactored UBI image building for IBM architectures into a dedicated
  `build-docker-ubi-ibm` job (matrix: `["s390x", "ppc64le"]`), separate from
  the existing `build-docker-ubi-redhat` job (matrix: `["amd64", "arm64"]`).
  This removes the need for per-step `if:` conditionals in the shared job.
- `build-docker-ubi-redhat` now runs unconditionally for `arm64`/`amd64`,
  publishing to Docker Hub, Amazon ECR, and ICR.
- `build-docker-ubi-ibm` publishes images only to
  `icr.io/cpopen/ibm-vault/` and `quay.io/redhat-isv-containers` (no Docker
  Hub / ECR), with no binary version check (cross-arch execution is not
  supported on the GitHub Actions runner).

### `.release/vault-k8s-artifacts.hcl`
- Registered the `ppc64le` binary zip artifact:
  `vault-k8s_${version}_linux_ppc64le.zip`.
- Registered the `ppc64le` UBI-based Docker tarballs:
  - `vault-k8s_ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar`
  - `vault-k8s_ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar`

### `Makefile`
- Added `--load` flag to the `docker build` command in the `image` target so
  locally built images are loaded into the Docker daemon (specifically for
  Podman support).

## Why

IBM Power (`ppc64le`) is a platform used in enterprise and regulated
environments, including OpenShift on IBM Power. This change extends vault-k8s's
multi-arch support to include `ppc64le` so it can be deployed natively on those
platforms without emulation.

## Testing

- `ppc64le` UBI image is manually tested in an OCP cluster and all integration
  tests passed.
- Binary version verification is intentionally skipped for `ppc64le` (consistent
  with `s390x` treatment) as the GitHub Actions runner cannot execute
  cross-architecture Docker containers natively.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
